### PR TITLE
Add FreeBSD packaging. Tested on FreeBSD 10,11 x86_64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,6 +93,7 @@ if [ "$1" == "package" ]; then
 	package "Windows" "windows" "amd64"
 	package "Mac" "darwin" "amd64"
 	package "Linux" "linux" "amd64"
+	package "FreeBSD" "freebsd" "amd64"
 	exit
 fi
 


### PR DESCRIPTION
Hi,

Also, I've create the tile38 port for FreeBSD platform: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=210147
And test iе щт various active FreeBSD version. Looks like all fine. It would be nice to mention the possibility of using your product on FreeBSD platform with installing from packages:

~~~
pkg install tile38
~~~

or from the ports:
~~~
make -C /usr/ports/databases/tile38 install
~~~

or via curl as usual for other OSes, when package tile38-1.2.0-freebsd-amd64.zip will be done
