### PR TITLE
Ignore VS Code folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ tile38-*
 data*/
 coverage.out 
 packages/
+
+# Ignore VS Code folder
+.vscode/


### PR DESCRIPTION
Hi,

VS Code is adding a '.vscode' folder to the source folder. This folder should be added to .gitignore.
