### PR TITLE
Fix incorrect query boundaries when using large radii

### DIFF
--- a/geojson/bbox.go
+++ b/geojson/bbox.go
@@ -241,7 +241,7 @@ func BBoxBounds(lat, lon, meters float64) (latMin, lonMin, latMax, lonMax float6
 		lonMax = lonMax
 	}
 
-	// Adjust for wraparound if minimum longitude is greater than 180 degrees.
+	// Adjust for wraparound if maximum longitude is greater than 180 degrees.
 	if lonMax > math.Pi {
 // box 1:
 		latMin = latMin

--- a/geojson/bbox.go
+++ b/geojson/bbox.go
@@ -241,7 +241,7 @@ func BBoxBounds(lat, lon, meters float64) (latMin, lonMin, latMax, lonMax float6
 		lonMax = lonMax
 	}
 
-	// Adjust for wraparound if minimum longitude is greater than -180 degrees.
+	// Adjust for wraparound if minimum longitude is greater than 180 degrees.
 	if lonMax > math.Pi {
 // box 1:
 		latMin = latMin


### PR DESCRIPTION
This patch fixes #64 by removing ```geo.DestinationPoint()``` from ```geojson.BBoxesFromCenter()``` and replacing it with a new function called ```geojson.BBoxBounds()``` that conforms to (the related sections of) http://janmatuschek.de/LatitudeLongitudeBoundingCoordinates#Latitude

If performance near the wraparound proves to be an issue, I or someone else can refactor, as mentioned in commented code inside of ```geojson.BBoxBounds()```.