### PR TITLE
Disable HTTP & WebSocket transports on demand.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 tile38-*
 !cmd/tile38-*
 data*/
-coverage.out 
+coverage.out
 packages/
 
-# Ignore VS Code folder
+# Ignore IDE folders
+.idea/
 .vscode/

--- a/cmd/tile38-server/main.go
+++ b/cmd/tile38-server/main.go
@@ -173,8 +173,6 @@ func main() {
   |_______|_______|   tile38.com
 `+"\n", core.Version, gitsha, strconv.IntSize, runtime.GOARCH, runtime.GOOS, hostd, port, os.Getpid(), httpTransportEnabled)
 
-	fmt.Printf("%v\n", httpTransport)
-
 	if err := controller.ListenAndServe(host, port, dir, httpTransport); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/tile38-server/main.go
+++ b/cmd/tile38-server/main.go
@@ -113,9 +113,9 @@ func main() {
 			i++
 			if i < len(os.Args) {
 				switch strings.ToLower(os.Args[i]) {
-				case "1", "true":
+				case "1", "true", "yes":
 					httpTransport = true
-				case "0", "false":
+				case "0", "false", "no":
 					httpTransport = false
 				}
 				continue

--- a/cmd/tile38-server/main.go
+++ b/cmd/tile38-server/main.go
@@ -32,6 +32,9 @@ var (
 	quiet       bool
 )
 
+// TODO: Set to false in 2.*
+var httpTransport bool = true
+
 // Fire up a webhook test server by using the --webhook-http-consumer-port
 // for example
 //   $ ./tile38-server --webhook-http-consumer-port 9999
@@ -106,6 +109,17 @@ func main() {
 		case "--dev", "-dev":
 			devMode = true
 			continue
+		case "--http-transport":
+			i++
+			if i < len(os.Args) {
+				switch strings.ToLower(os.Args[i]) {
+				case "1", "true":
+					httpTransport = true
+				case "0", "false":
+					httpTransport = false
+				}
+				continue
+			}
 		}
 		nargs = append(nargs, os.Args[i])
 	}
@@ -118,6 +132,7 @@ func main() {
 	flag.BoolVar(&quiet, "q", false, "Quiet logging. Totally silent.")
 	flag.BoolVar(&veryVerbose, "vv", false, "Enable very verbose logging.")
 	flag.Parse()
+
 	var logw io.Writer = os.Stderr
 	if quiet {
 		logw = ioutil.Discard
@@ -138,6 +153,11 @@ func main() {
 		gitsha = ""
 	}
 
+	httpTransportEnabled := "Enabled"
+	if !httpTransport {
+		httpTransportEnabled = "Disabled"
+	}
+
 	//  _____ _ _     ___ ___
 	// |_   _|_| |___|_  | . |
 	//   | | | | | -_|_  | . |
@@ -148,12 +168,14 @@ func main() {
   |       |       |
   |____   |   _   |   Tile38 %s%s %d bit (%s/%s)
   |       |       |   %sPort: %d, PID: %d
-  |____   |   _   |
-  |       |       |   tile38.com
-  |_______|_______|
-`+"\n", core.Version, gitsha, strconv.IntSize, runtime.GOARCH, runtime.GOOS, hostd, port, os.Getpid())
+  |____   |   _   |   HTTP & WebSocket transports: %s
+  |       |       |
+  |_______|_______|   tile38.com
+`+"\n", core.Version, gitsha, strconv.IntSize, runtime.GOARCH, runtime.GOOS, hostd, port, os.Getpid(), httpTransportEnabled)
 
-	if err := controller.ListenAndServe(host, port, dir); err != nil {
+	fmt.Printf("%v\n", httpTransport)
+
+	if err := controller.ListenAndServe(host, port, dir, httpTransport); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -100,10 +100,10 @@ type Controller struct {
 }
 
 // ListenAndServe starts a new tile38 server
-func ListenAndServe(host string, port int, dir string) error {
-	return ListenAndServeEx(host, port, dir, nil)
+func ListenAndServe(host string, port int, dir string, http bool) error {
+	return ListenAndServeEx(host, port, dir, nil, http)
 }
-func ListenAndServeEx(host string, port int, dir string, ln *net.Listener) error {
+func ListenAndServeEx(host string, port int, dir string, ln *net.Listener, http bool) error {
 	log.Infof("Server started, Tile38 version %s, git %s", core.Version, core.GitSHA)
 	c := &Controller{
 		host:     host,
@@ -221,7 +221,7 @@ func ListenAndServeEx(host string, port int, dir string, ln *net.Listener) error
 		delete(c.conns, conn)
 		c.mu.Unlock()
 	}
-	return server.ListenAndServe(host, port, protected, handler, opened, closed, ln)
+	return server.ListenAndServe(host, port, protected, handler, opened, closed, ln, http)
 }
 
 func (c *Controller) watchMemory() {

--- a/tests/mock_test.go
+++ b/tests/mock_test.go
@@ -51,7 +51,7 @@ func mockOpenServer() (*mockServer, error) {
 	s := &mockServer{port: port}
 	tlog.Default = tlog.New(logOutput, nil)
 	go func() {
-		if err := controller.ListenAndServe("localhost", port, dir); err != nil {
+		if err := controller.ListenAndServe("localhost", port, dir, true); err != nil {
 			log.Fatal(err)
 		}
 	}()


### PR DESCRIPTION
Simple **HTTP** & **WebSocket** transport disabling by using:
```bash
./tile38-server --http-transport false
```

Resolving: #92 

@tidwall need your review.