### PR TITLE
Fix leaking http connections

### DIFF
--- a/controller/endpoint/http.go
+++ b/controller/endpoint/http.go
@@ -19,15 +19,12 @@ const (
 type HTTPEndpointConn struct {
 	mu     sync.Mutex
 	ep     Endpoint
-	ex     bool
-	t      time.Time
 	client *http.Client
 }
 
 func newHTTPEndpointConn(ep Endpoint) *HTTPEndpointConn {
 	return &HTTPEndpointConn{
 		ep: ep,
-		t:  time.Now(),
 	}
 }
 
@@ -38,10 +35,7 @@ func (conn *HTTPEndpointConn) Expired() bool {
 func (conn *HTTPEndpointConn) Send(msg string) error {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
-	if conn.ex {
-		return errExpired
-	}
-	conn.t = time.Now()
+
 	if conn.client == nil {
 		conn.client = &http.Client{
 			Transport: &http.Transport{

--- a/controller/endpoint/http.go
+++ b/controller/endpoint/http.go
@@ -33,15 +33,7 @@ func newHTTPEndpointConn(ep Endpoint) *HTTPEndpointConn {
 }
 
 func (conn *HTTPEndpointConn) Expired() bool {
-	conn.mu.Lock()
-	defer conn.mu.Unlock()
-	if !conn.ex {
-		if time.Now().Sub(conn.t) > httpExpiresAfter {
-			conn.ex = true
-			conn.client = nil
-		}
-	}
-	return conn.ex
+	return false
 }
 
 func (conn *HTTPEndpointConn) Send(msg string) error {
@@ -55,6 +47,7 @@ func (conn *HTTPEndpointConn) Send(msg string) error {
 		conn.client = &http.Client{
 			Transport: &http.Transport{
 				MaxIdleConnsPerHost: httpMaxIdleConnections,
+				IdleConnTimeout:     httpExpiresAfter,
 			},
 			Timeout: httpRequestTimeout,
 		}


### PR DESCRIPTION
We faced problems with leaking http connections. We receive hooks by http, all connections are keep-alived. After few hours of our testing we noticed that we\`ve got ~400 opened connections despite of hardcoded limit to 20. Also we had same number of goroutines both on server & client sides. 

Default http client runs standalone goroutine for every connection so code in `Expired` doesn\`t close these connections it just set client to `nil`. And new created client opens and runs new goroutines for new connection.