### PR TITLE
remove mutex from HTTP endpoint

### DIFF
--- a/controller/endpoint/http.go
+++ b/controller/endpoint/http.go
@@ -19,15 +19,12 @@ const (
 type HTTPEndpointConn struct {
 	mu     sync.Mutex
 	ep     Endpoint
-	ex     bool
-	t      time.Time
 	client *http.Client
 }
 
 func newHTTPEndpointConn(ep Endpoint) *HTTPEndpointConn {
 	return &HTTPEndpointConn{
 		ep: ep,
-		t:  time.Now(),
 	}
 }
 
@@ -38,10 +35,7 @@ func (conn *HTTPEndpointConn) Expired() bool {
 func (conn *HTTPEndpointConn) Send(msg string) error {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
-	if conn.ex {
-		return errExpired
-	}
-	conn.t = time.Now()
+
 	if conn.client == nil {
 		conn.client = &http.Client{
 			Transport: &http.Transport{

--- a/controller/endpoint/http.go
+++ b/controller/endpoint/http.go
@@ -33,15 +33,7 @@ func newHTTPEndpointConn(ep Endpoint) *HTTPEndpointConn {
 }
 
 func (conn *HTTPEndpointConn) Expired() bool {
-	conn.mu.Lock()
-	defer conn.mu.Unlock()
-	if !conn.ex {
-		if time.Now().Sub(conn.t) > httpExpiresAfter {
-			conn.ex = true
-			conn.client = nil
-		}
-	}
-	return conn.ex
+	return false
 }
 
 func (conn *HTTPEndpointConn) Send(msg string) error {
@@ -55,6 +47,7 @@ func (conn *HTTPEndpointConn) Send(msg string) error {
 		conn.client = &http.Client{
 			Transport: &http.Transport{
 				MaxIdleConnsPerHost: httpMaxIdleConnections,
+				IdleConnTimeout:     httpExpiresAfter,
 			},
 			Timeout: httpRequestTimeout,
 		}


### PR DESCRIPTION
Client can be created once in constructor so mutex isn`t required anymore.