### PR TITLE
Include tile38-cli in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ RUN apk update \
     && tar -xzvf tile38.tar.gz \
     && rm -f tile38.tar.gz \
     && mv tile38-$TILE38_VERSION-linux-amd64/tile38-server /usr/local/bin \
+    && mv tile38-$TILE38_VERSION-linux-amd64/tile38-cli /usr/local/bin \
     && rm -fR tile38-$TILE38_VERSION-linux-amd64
 
 RUN mkdir /data && chown tile38:tile38 /data


### PR DESCRIPTION
Just trying out Tile38 for the first time, and liking it.

I'm used to using `redis-cli` in the Redis image, and `psql` in the Postgres image, so I was surprised to not find `tile38-cli` in the Tile38 image. Could we add it?