### PR TITLE
[FIX] Too few arguments in call to controller.ListenAndServe

### DIFF
--- a/tests/107/main.go
+++ b/tests/107/main.go
@@ -101,7 +101,7 @@ func main() {
 
 func startTile38Server() {
 	log.Println("start tile38 server")
-	err := controller.ListenAndServe("localhost", tile38Port, "data")
+	err := controller.ListenAndServe("localhost", tile38Port, "data", true)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
There is signature:
```go
// ListenAndServe starts a new tile38 server
func ListenAndServe(host string, port int, dir string, http bool) error {
	return ListenAndServeEx(host, port, dir, nil, http)
}
```