### PR TITLE
Fix pkg/core/gen.sh so that make works on linux

### DIFF
--- a/pkg/core/gen.sh
+++ b/pkg/core/gen.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-cd $(dirname "${BASH_SOURCE[0]}")
-export CommandsJSON=$(cat commands.json)
+cd $(dirname $0)
+export CommandsJSON="$(cat commands.json)"
 
 # replace out the json
 perl -pe '


### PR DESCRIPTION
Make was failing for me on linux.  With these changes things seem to work on both linux and mac.