### PR TITLE
CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,16 @@
 language: go
-script: make test
+
+services:
+  - docker
+
+script: 
+  - make test
+
+after_success:
+  - echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin
+  - export REPO=$DOCKER_USER/tile38
+  - export COMMIT_SHORT=$(git rev-parse --short HEAD)
+  - docker build -f docker/Dockerfile -t $REPO:$COMMIT_SHORT .
+  - export TAG=`if [ ! -z "$TRAVIS_TAG" ]; then echo $TRAVIS_TAG; elif [ "$TRAVIS_BRANCH" == "master" ]; then echo "edge"; else echo ""; fi`
+  - if [[ ! -z "$TAG" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then docker tag $REPO:$COMMIT_SHORT $REPO:$TAG && docker push $REPO:$TAG && echo "Pushed $REPO:$TAG"; else echo "Not pushing, either not on master or on a PR"; fi
+  - if [[ ! -z "$TRAVIS_TAG" ]]; then docker tag $REPO:$COMMIT_SHORT $REPO:latest && docker push $REPO:latest && echo "Pushed $REPO:latest"; else echo "Not pushing, no tag"; fi

--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,4 @@ uninstall:
 	rm -f /usr/local/bin/tile38-cli
 	rm -f /usr/local/bin/tile38-benchmark
 package:
-package:
 	@./build.sh package

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION="1.12.0"
+VERSION=$(git describe --tags | sed 's/-/\n/g' | head -n 1)
 PROTECTED_MODE="no"
 
 # Hardcode some values to the core package
@@ -119,7 +119,6 @@ function rmtemp {
 	rm -rf "$TMP"
 }
 trap rmtemp EXIT
-
 
 if [ "$NOLINK" != "1" ]; then
     # symlink root to isolated directory

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION=$(git describe --tags | sed 's/-/\n/g' | head -n 1)
+VERSION=$(git describe --tags --abbrev=0)
 PROTECTED_MODE="no"
 
 # Hardcode some values to the core package

--- a/build.sh
+++ b/build.sh
@@ -132,10 +132,10 @@ fi
 pkg/core/gen.sh
 
 # build and store objects into original directory.
-go build -ldflags "$LDFLAGS" -o "$OD/tile38-server" cmd/tile38-server/*.go
-go build -ldflags "$LDFLAGS" -o "$OD/tile38-cli" cmd/tile38-cli/*.go
-go build -ldflags "$LDFLAGS" -o "$OD/tile38-benchmark" cmd/tile38-benchmark/*.go
-go build -ldflags "$LDFLAGS" -o "$OD/tile38-luamemtest" cmd/tile38-luamemtest/*.go
+CGO_ENABLED=0 go build -ldflags "$LDFLAGS -extldflags '-static'" -o "$OD/tile38-server" cmd/tile38-server/*.go
+CGO_ENABLED=0 go build -ldflags "$LDFLAGS -extldflags '-static'" -o "$OD/tile38-cli" cmd/tile38-cli/*.go
+CGO_ENABLED=0 go build -ldflags "$LDFLAGS -extldflags '-static'" -o "$OD/tile38-benchmark" cmd/tile38-benchmark/*.go
+CGO_ENABLED=0 go build -ldflags "$LDFLAGS -extldflags '-static'" -o "$OD/tile38-luamemtest" cmd/tile38-luamemtest/*.go
 
 # test if requested
 if [ "$1" == "test" ]; then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,13 @@
 FROM alpine:3.4
 
-ENV TILE38_VERSION 1.12.0
-ENV TILE38_DOWNLOAD_URL https://github.com/tidwall/tile38/releases/download/$TILE38_VERSION/tile38-$TILE38_VERSION-linux-amd64.tar.gz
+ADD ./tile38-server /usr/local/bin
+ADD ./tile38-cli /usr/local/bin
 
-RUN addgroup -S tile38 && adduser -S -G tile38 tile38
-
-RUN apk update \
-    && apk add ca-certificates \
-    && update-ca-certificates \
-    && apk add openssl \
-    && wget -O tile38.tar.gz "$TILE38_DOWNLOAD_URL" \
-    && tar -xzvf tile38.tar.gz \
-    && rm -f tile38.tar.gz \
-    && mv tile38-$TILE38_VERSION-linux-amd64/tile38-server /usr/local/bin \
-    && mv tile38-$TILE38_VERSION-linux-amd64/tile38-cli /usr/local/bin \
-    && rm -fR tile38-$TILE38_VERSION-linux-amd64
-
-RUN mkdir /data && chown tile38:tile38 /data
+RUN addgroup -S tile38 && \
+    adduser -S -G tile38 tile38 && \
+    mkdir /data && chown tile38:tile38 /data
 
 VOLUME /data
-WORKDIR /data
 
 EXPOSE 9851
-CMD ["tile38-server"]
+CMD ["tile38-server", "-d", "/data"]


### PR DESCRIPTION
This PR contains:

* Automatic version detection by using git tags
* Fix for the Makefile (double package target)
* Enable Travis CI to build the Docker images and push to Docker Hub
  * You'll need to set up the `DOCKER_USER` and `DOCKER_PASSWORD` environment variables in the Travis CI project/repo as described in https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings
   * Logic for Docker image tags is:
     * If the push refers to a git tag, the Docker image tag will be the git tag
     * If the push is on master, it will get pushed to the `edge` Docker image tag
     * `latest will àlways refer to the last created git tag

What I noticed is that the Docker images build via Travis will trigger an error when being started, because ther's apparently a problem in the go build (non-static linking?):

```text
On local machine

$ docker run -it tobilg/tile38:edge
standard_init_linux.go:190: exec user process caused "no such file or directory"
$ docker run -it --entrypoint sh tobilg/tile38:edge

In the Docker image

/ # cd /usr/local/bin/
/usr/local/bin # ldd tile38-server
        /lib64/ld-linux-x86-64.so.2 (0x7fe2e1be6000)
        libpthread.so.0 => /lib64/ld-linux-x86-64.so.2 (0x7fe2e1be6000)
        libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7fe2e1be6000)
/ # which tile38-server
/usr/local/bin/tile38-server
/ # tile38-server
sh: tile38-server: not found
/ # mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2

After linking the musl
/ # tile38-server
   _______ _______
  |       |       |
  |____   |   _   |   Tile38 1.12.0 (75e0abf) 64 bit (amd64/linux)
  |       |       |   Port: 9851, PID: 17
  |____   |   _   |
  |       |       |   tile38.com, patreon.com/tidwall
  |_______|_______|
2018/04/24 06:58:50 [INFO] Server started, Tile38 version 1.12.0, git 75e0abf
2018/04/24 06:58:50 [INFO] AOF loaded 0 commands: 0.00s, 0/s, 0 bytes/s
2018/04/24 06:58:50 [INFO] The server is now ready to accept connections on port 9851
```

I guess this needs to be addressed before enabling the new CI process. I can create an issue if you like @tidwall. Thanks.