### PR TITLE
handle Ctrl-D

### DIFF
--- a/cmd/tile38-cli/main.go
+++ b/cmd/tile38-cli/main.go
@@ -375,6 +375,8 @@ func main() {
 			}
 		} else if err == liner.ErrPromptAborted {
 			return
+		} else if err == io.EOF {
+			os.Exit(0)
 		} else {
 			fmt.Fprintf(os.Stderr, "Error reading line: %s", err.Error())
 		}


### PR DESCRIPTION
when I hit Ctrl-D, I mean to exit, rather than to see the annoying "Error reading line: EOF"