### PR TITLE
Add server command for `version` - closes #384

### DIFF
--- a/internal/server/stats.go
+++ b/internal/server/stats.go
@@ -115,6 +115,7 @@ func (c *Server) cmdServer(msg *Message) (res resp.Value, err error) {
 	m["heap_released"] = mem.HeapReleased
 	m["max_heap_size"] = c.config.maxMemory()
 	m["avg_item_size"] = avgsz
+	m["version"] = core.Version
 	m["pointer_size"] = (32 << uintptr(uint64(^uintptr(0))>>63)) / 8
 	m["read_only"] = c.config.readOnly()
 	m["cpus"] = runtime.NumCPU()


### PR DESCRIPTION
Would you rather have a `version` or `server_version` in the output?