### PR TITLE
ca-certs in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.4
+RUN apk add --no-cache ca-certificates
 
 ADD tile38-server /usr/local/bin
 ADD tile38-cli /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.8
 RUN apk add --no-cache ca-certificates
 
 ADD tile38-server /usr/local/bin


### PR DESCRIPTION
Resolves https://github.com/tidwall/tile38/issues/392. 1.12.0 had a wildly different Dockerfile which did include the CA-certs install. This change adds them to the new alpine image.