### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,34 @@
+name: tile38
+version: '1.0'
+summary: Tile38 is a geospatial database, spatial index, and realtime geofence
+description: |
+  Tile38 is a geospatial database, spatial index, and realtime geofence. 
+grade: stable
+confinement: strict
+base: core18
+parts:
+  tile38:
+    plugin: go
+    source: https://github.com/tidwall/tile38.git
+    go-importpath: github.com/tidwall/tile38
+    build-packages:
+      - build-essential
+apps:
+  tile38-server:
+    command: bin/tile38-server
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind
+  tile38-cli:
+    command: bin/tile38-cli
+    plugs:
+      - home
+      - network
+  tile38-benchmark:
+    command: bin/tile38-benchmark
+    plugs:
+      - home
+      - network


### PR DESCRIPTION
Hi Josh,

I opened this PR to ask you about adding support for snaps.

This is a cool project, and it would be a nice addition to the Snap Store.

So, the technical magic:

Snaps are cross-distro Linux software packages, supported on Ubuntu, Debian, Manjaro, Fedora, OpenSUSE and many others distributions. They also come with automatic updates. The Snap Store (snapcraft.io/store) has an audience of millions, and this could perhaps help you connect even more people with your project.

I built tile38 as a snap locally using our command line tool snapcraft. You can also build online using our free build system (build.snapcraft.io), or integrate into an existing CI/build tool. I've detailed below the steps to create the snap locally on Ubuntu 18.04. The final snap has the server, cli and benchmark binaries.

- Install snapcraft & build snap.

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/tile38.git
cd tile38
git checkout add-snapcraft
snapcraft

This creates <tile38-version>.snap file, something like tile38_1.0_amd64.snap. You can change/tweak the snapcraft.yaml file included in this PR as you like, and use any versioning scheme. The version field carries no semantic meaning, so you can match this to your app release or snap release revision.

- Test snap (local test before uploading to the store).

This is done by running:

snap install tile38_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the app isn't signed yet (it will be once uploaded to the store).

After it's installed, you can run the application and test the functionality

snap run tile38.<binary> <options>, e.g.: snap run tile38.tile38-cli (this returns the prompt).

Later on, you can request aliases if you like, so that you don't need to do the invocation as above but just tile38-cli, for instance.

- Register & upload to the store.

A couple of steps here:

Register a developer account in the snap store https://snapcraft.io/account.
Register the tile38 name in the store. 

snapcraft login
snapcraft register

snapcraft push tile38_1.0_amd64.snap --release edge

We use channels to denote risk - available channels include edge, beta, candidate, stable. Typically, you start with edge and then push to other channels after testing, and you're happy the app is stable and works well.

- Test installing on a clean machine.

The last step is to install from the store and see that everything works as expected.

snap install tile38 --edge

That's about it. Once all these steps are complete, we'd be happy to help you with the store page and promotion.

BTW, are you associated in any way to Randall (xkcd)?

Finally, is that a real falcon in your avatar?
