### PR TITLE
Release aof buffer periodically

### DIFF
--- a/internal/server/aof.go
+++ b/internal/server/aof.go
@@ -115,11 +115,16 @@ func commandErrIsFatal(err error) bool {
 	return true
 }
 
-func (server *Server) flushAOF() {
+func (server *Server) flushAOF(sync bool) {
 	if len(server.aofbuf) > 0 {
 		_, err := server.aof.Write(server.aofbuf)
 		if err != nil {
 			panic(err)
+		}
+		if sync {
+			if err := server.aof.Sync(); err != nil {
+				panic(err)
+			}
 		}
 		server.aofbuf = server.aofbuf[:0]
 	}

--- a/internal/server/aofshrink.go
+++ b/internal/server/aofshrink.go
@@ -236,7 +236,7 @@ func (server *Server) aofshrink() {
 			defer server.mu.Unlock()
 
 			// flush the aof buffer
-			server.flushAOF()
+			server.flushAOF(false)
 
 			aofbuf = aofbuf[:0]
 			for _, values := range server.shrinklog {

--- a/internal/server/follow.go
+++ b/internal/server/follow.go
@@ -165,7 +165,7 @@ func (c *Server) followHandleCommand(args []string, followc int, w io.Writer) (i
 		return c.aofsz, err
 	}
 	if len(c.aofbuf) > 10240 {
-		c.flushAOF()
+		c.flushAOF(false)
 	}
 	return c.aofsz, nil
 }
@@ -291,7 +291,7 @@ func (c *Server) followStep(host string, port int, followc int) error {
 			if aofsz >= int(aofSize) {
 				caughtUp = true
 				c.mu.Lock()
-				c.flushAOF()
+				c.flushAOF(false)
 				c.fcup = true
 				c.fcuponce = true
 				c.mu.Unlock()


### PR DESCRIPTION
The AOF buffer can occasionally grow very large, which is OK, but the memory should be occasionally released.