### PR TITLE
Ignore SIGHUP signals

### DIFF
--- a/cmd/tile38-server/main.go
+++ b/cmd/tile38-server/main.go
@@ -291,22 +291,24 @@ Developer Options:
 
 	signal.Notify(c, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
-		s := <-c
-		log.Warnf("signal: %v", s)
-		if pidfile != "" {
-			cleanup()
-		}
-		switch {
-		default:
-			os.Exit(-1)
-		case s == syscall.SIGHUP:
-			os.Exit(1)
-		case s == syscall.SIGINT:
-			os.Exit(2)
-		case s == syscall.SIGQUIT:
-			os.Exit(3)
-		case s == syscall.SIGTERM:
-			os.Exit(0xf)
+		for s := range c {
+			if s == syscall.SIGHUP {
+				continue
+			}
+			log.Warnf("signal: %v", s)
+			if pidfile != "" {
+				cleanup()
+			}
+			switch {
+			default:
+				os.Exit(-1)
+			case s == syscall.SIGINT:
+				os.Exit(2)
+			case s == syscall.SIGQUIT:
+				os.Exit(3)
+			case s == syscall.SIGTERM:
+				os.Exit(0xf)
+			}
 		}
 	}()
 


### PR DESCRIPTION
A SIGHUP should not kill the process.  `kill -SIGHUP <pid>` should gracefully be ignored.

More details at https://github.com/tidwall/tile38/issues/418#issuecomment-472009607