### PR TITLE
MQTT clientId should be unique

### DIFF
--- a/internal/endpoint/mqtt.go
+++ b/internal/endpoint/mqtt.go
@@ -3,7 +3,7 @@ package endpoint
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/rand"
+	"math/rand"
 	"fmt"
 	"io/ioutil"
 	"sync"

--- a/internal/endpoint/mqtt.go
+++ b/internal/endpoint/mqtt.go
@@ -83,7 +83,9 @@ func (conn *MQTTConn) Send(msg string) error {
 			}
 			ops = ops.SetTLSConfig(&config)
 		}
-		ops = ops.SetClientID("tile38").AddBroker(uri)
+		nano := time.Now().UnixNano()
+		clientID := fmt.Sprintf("tile38_%x", nano) //the id of connected clients should be unique
+		ops = ops.SetClientID(clientID).AddBroker(uri)
 		c := paho.NewClient(ops)
 
 		if token := c.Connect(); token.Wait() && token.Error() != nil {


### PR DESCRIPTION
Each mqtt hook establishes separate connection to the MQTT broker. If
their clientIds are all equal the MQTT broker will disconnect the clients - the
protocol does not allow 2 connected clients with the same name