### PR TITLE
Strictly check if values passed to JSET are numbers

### DIFF
--- a/internal/server/json.go
+++ b/internal/server/json.go
@@ -41,52 +41,80 @@ func jsonString(s string) string {
 	return string(b)
 }
 
-func isJsonNumber(s string) bool {
+func isJsonNumber(data string) bool {
 	// Returns true if the given string can be encoded as a JSON number value.
 	// See:
 	// https://json.org
 	// http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
-	l := len(s)
-	if l == 0 {
+	if data == "" {
 		return false
 	}
 	i := 0
-	if s[i] == '-' {
+	// sign
+	if data[i] == '-' {
 		i++
 	}
-	switch {
-	case i == l:
+	if i == len(data) {
 		return false
-	case s[i] == '0': // 0 must not be followed by any digits.
+	}
+	// int
+	if data[i] == '0' {
 		i++
-		break
-	case s[i] >= '1' && s[0] <= '9':
-		for i++; i < l && s[i] >= '0' && s[i] <= '9'; i++ { // scan over digits
+	} else {
+		for ; i < len(data); i++ {
+			if data[i] >= '0' && data[i] <= '9' {
+				continue
+			}
+			break
 		}
-	default:
-		return false
 	}
-	if i == l {
+	// frac
+	if i == len(data) {
 		return true
 	}
-	if  l-i > 1 && s[i] == '.' {
-		for i++; i < l && s[i] >= '0' && s[i] <= '9'; i++ {
+	if data[i] == '.' {
+		i++
+		if i == len(data) {
+			return false
+		}
+		if data[i] < '0' || data[i] > '9' {
+			return false
+		}
+		i++
+		for ; i < len(data); i++ {
+			if data[i] >= '0' && data[i] <= '9' {
+				continue
+			}
+			break
 		}
 	}
-	if l-i > 1 && (s[i] == 'e' || s[i] == 'E') {
+	// exp
+	if i == len(data) {
+		return true
+	}
+	if data[i] == 'e' || data[i] == 'E' {
 		i++
-		if s[i] == '-' || s[i] == '+' {
+		if i == len(data) {
+			return false
+		}
+		if data[i] == '+' || data[i] == '-' {
 			i++
 		}
-		switch {
-		case i == l:
+		if i == len(data) {
 			return false
-		case s[i] >= '0' && s[0] <= '9':
-			for i++; i < l && s[i] >= '0' && s[i] <= '9'; i++ {
+		}
+		if data[i] < '0' || data[i] > '9' {
+			return false
+		}
+		i++
+		for ; i < len(data); i++ {
+			if data[i] >= '0' && data[i] <= '9' {
+				continue
 			}
+			break
 		}
 	}
-	return i == l
+	return i == len(data)
 }
 
 func appendJSONSimpleBounds(dst []byte, o geojson.Object) []byte {

--- a/internal/server/json_test.go
+++ b/internal/server/json_test.go
@@ -18,3 +18,29 @@ func BenchmarkJSONMarshal(t *testing.B) {
 		json.Marshal(s)
 	}
 }
+
+func TestIsJsonNumber(t *testing.T) {
+	test := func(expected bool, val string) {
+		actual := isJsonNumber(val)
+		if expected != actual {
+			t.Fatalf("Expected %t == isJsonNumber(\"%s\") but was %t", expected, val, actual)
+		}
+	}
+	test(false, "")
+	test(false, "-")
+	test(false, "foo")
+	test(false, "0123")
+	test(false, "1.")
+	test(false, "1.0e")
+	test(false, "1.0e-")
+	test(false, "1.0E10NaN")
+	test(false, "1.0ENaN")
+	test(true, "-1")
+	test(true, "0")
+	test(true, "0.0")
+	test(true, "42")
+	test(true, "1.0E10")
+	test(true, "1.0e10")
+	test(true, "1E+5")
+	test(true, "1E-10")
+}

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -5,6 +5,8 @@ import "testing"
 func subTestJSON(t *testing.T, mc *mockServer) {
 	runStep(t, mc, "basic", json_JSET_basic_test)
 	runStep(t, mc, "geojson", json_JSET_geojson_test)
+	runStep(t, mc, "number", json_JSET_number_test)
+
 }
 func json_JSET_basic_test(mc *mockServer) error {
 	return mc.DoBatch([][]interface{}{
@@ -37,5 +39,18 @@ func json_JSET_geojson_test(mc *mockServer) error {
 		{"JSET", "mykey", "myid1", "properties.tags.-1", "hot"}, {"OK"},
 		{"JGET", "mykey", "myid1"}, {`{"type":"Feature","geometry":{"type":"Point","coordinates":[-115,44]},"properties":{"tags":["southwest","united states","hot"]}}`},
 		{"JDEL", "mykey", "myid1", "type"}, {"ERR missing type"},
+	})
+}
+
+func json_JSET_number_test(mc *mockServer) error {
+	return mc.DoBatch([][]interface{}{
+		{"JSET", "mykey", "myid1", "hello", "0"}, {"OK"},
+		{"JGET", "mykey", "myid1"}, {`{"hello":0}`},
+		{"JSET", "mykey", "myid1", "hello", "0123"}, {"OK"},
+		{"JGET", "mykey", "myid1"}, {`{"hello":"0123"}`},
+		{"JSET", "mykey", "myid1", "hello", "3.14"}, {"OK"},
+		{"JGET", "mykey", "myid1"}, {`{"hello":3.14}`},
+		{"JSET", "mykey", "myid1", "hello", "1.0e10"}, {"OK"},
+		{"JGET", "mykey", "myid1"}, {`{"hello":1.0e10}`},
 	})
 }


### PR DESCRIPTION
This PR adds a new function that validates if a string is a number according to the JSON spec, replacing the call to ParseFloat. This fixes #493

This is my first experience with Go, so please let me know if I did something wrong, or if there is a more idiomatic way of doing things.