### PR TITLE
Fix fprintf type error in stats_cpu.go for non-linux/darwin builds

### DIFF
--- a/internal/server/stats_cpu.go
+++ b/internal/server/stats_cpu.go
@@ -13,6 +13,6 @@ func (s *Server) writeInfoCPU(w *bytes.Buffer) {
 			"used_cpu_user:%.2f\r\n"+
 			"used_cpu_sys_children:%.2f\r\n"+
 			"used_cpu_user_children:%.2f\r\n",
-		0, 0, 0, 0,
+		0.0, 0.0, 0.0, 0.0,
 	)
 }


### PR DESCRIPTION
Fixes " Fprintf format %.2f has arg 0 of wrong type int" error when running tests on Windows
