### PR TITLE
Fix a concurrent write/read on the server conn map

### DIFF
--- a/internal/server/follow.go
+++ b/internal/server/follow.go
@@ -121,9 +121,13 @@ func (s *Server) cmdReplConf(msg *Message, client *Client) (res resp.Value, err 
 		}
 
 		// Apply the replication port to the client and return
+		s.connsmu.RLock()
+		defer s.connsmu.RUnlock()
 		for _, c := range s.conns {
 			if c.remoteAddr == client.remoteAddr {
+				c.mu.Lock()
 				c.replPort = port
+				c.mu.Unlock()
 				return OKMessage(msg, start), nil
 			}
 		}


### PR DESCRIPTION
We encountered the following crash, this PR should fix


fatal error: concurrent map iteration and map write
goroutine 6756 [running]:
runtime.throw(0xd48942, 0x26)
        /usr/local/go/src/runtime/panic.go:617 +0x72 fp=0xc000dbced8 sp=0xc000dbcea8 pc=0x42d722
runtime.mapiternext(0xc000dbd030)
        /usr/local/go/src/runtime/map.go:860 +0x597 fp=0xc000dbcf60 sp=0xc000dbced8 pc=0x40efa7
github.com/tidwall/tile38/internal/server.(*Server).cmdReplConf(0xc000364000, 0xc7b2a1dc20, 0xc0005a2000, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /tmp/tile38.t7dy/go/src/github.com/tidwall/tile38/internal/server/follow.go:124 +0x3cc fp=0xc000dbd0a0 sp=0xc000dbcf60 pc=0xb1700c
github.com/tidwall/tile38/internal/server.(*Server).command(0xc000364000, 0xc7b2a1dc20, 0xc0005a2000, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /tmp/tile38.t7dy/go/src/github.com/tidwall/tile38/internal/server/server.go:993 +0x4d4a fp=0xc000dbd5b8 sp=0xc000dbd0a0 pc=0xb4d51a
github.com/tidwall/tile38/internal/server.(*Server).handleInputCommand.func4(0xc7b2a1dc20, 0xd5fea45b00, 0xf226842f90, 0xc000364000, 0xc0005a2000, 0x0, 0x0, 0x0, 0x0, 0x0, 
...)
        /tmp/tile38.t7dy/go/src/github.com/tidwall/tile38/internal/server/server.go:870 +0x340 fp=0xc000dbd9a0 sp=0xc000dbd5b8 pc=0xb73560
github.com/tidwall/tile38/internal/server.(*Server).handleInputCommand(0xc000364000, 0xc0005a2000, 0xc7b2a1dc20, 0x0, 0x0)
        /tmp/tile38.t7dy/go/src/github.com/tidwall/tile38/internal/server/server.go:871 +0x991 fp=0xc000dbde10 sp=0xc000dbd9a0 pc=0xb46091
github.com/tidwall/tile38/internal/server.(*Server).netServe.func1(0xc000343598, 0xc000364000, 0xeed060, 0xc0001760d8)
        /tmp/tile38.t7dy/go/src/github.com/tidwall/tile38/internal/server/server.go:414 +0x422 fp=0xc000dbdfc0 sp=0xc000dbde10 pc=0xb71112
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1337 +0x1 fp=0xc000dbdfc8 sp=0xc000dbdfc0 pc=0x45cc91
created by github.com/tidwall/tile38/internal/server.(*Server).netServe
        /tmp/tile38.t7dy/go/src/github.com/tidwall/tile38/internal/server/server.go:318 +0x244