### PR TITLE
Set Indexing Kind in geometry to whatever it is set on the server.

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -197,10 +197,13 @@ func Serve(host string, port int, dir string, http bool) error {
 	case "":
 	case "None":
 		server.geomParseOpts.IndexGeometryKind = geometry.None
+		geometry.DefaultIndexOptions.Kind = geometry.None
 	case "RTree":
 		server.geomParseOpts.IndexGeometryKind = geometry.RTree
+		geometry.DefaultIndexOptions.Kind = geometry.RTree
 	case "QuadTree":
 		server.geomParseOpts.IndexGeometryKind = geometry.QuadTree
+		geometry.DefaultIndexOptions.Kind = geometry.QuadTree
 	}
 	if server.geomParseOpts.IndexGeometryKind == geometry.None {
 		log.Debugf("Geom indexing: %s",


### PR DESCRIPTION
When the server is started with the non-default indexing option (through env var), the geojson.geometry indexing is still the default QuadTree.  This means that the clipped polygons will not be indexed like stored polygons.

This PR fixed this issue.