### PR TITLE
Optimize field match.

### DIFF
--- a/internal/server/scanner.go
+++ b/internal/server/scanner.go
@@ -248,12 +248,10 @@ func (sw *scanWriter) fieldMatch(fields []float64, o geojson.Object) (fvals []fl
 			}
 		}
 	} else {
-		for idx := range sw.farr {
-			var value float64
-			if len(fields) > idx {
-				value = fields[idx]
-			}
-			sw.fvals[idx] = value
+		copy(sw.fvals, fields)
+		// fields might be shorter for this item, need to pad sw.fvals with zeros
+		for i := len(fields); i < len(sw.fvals); i++ {
+			sw.fvals[i] = 0
 		}
 		for _, where := range sw.wheres {
 			if where.field == "z" {
@@ -267,21 +265,13 @@ func (sw *scanWriter) fieldMatch(fields []float64, o geojson.Object) (fvals []fl
 				}
 				continue
 			}
-			var value float64
-			idx, ok := sw.fmap[where.field]
-			if ok {
-				value = sw.fvals[idx]
-			}
+			value := sw.fvals[sw.fmap[where.field]]
 			if !where.match(value) {
 				return
 			}
 		}
 		for _, wherein := range sw.whereins {
-			var value float64
-			idx, ok := sw.fmap[wherein.field]
-			if ok {
-				value = sw.fvals[idx]
-			}
+			value := sw.fvals[sw.fmap[wherein.field]]
 			if !wherein.match(value) {
 				return
 			}

--- a/internal/server/scanner.go
+++ b/internal/server/scanner.go
@@ -119,18 +119,18 @@ func (s *Server) newScanWriter(
 		// so we don't have to map string field names for each tested object
 		var ok bool
 		if len(wheres) > 0 {
-			sw.wheres = make([]whereT, 0, len(wheres))
+			sw.wheres = make([]whereT, len(wheres))
 			for i, where := range wheres {
-				if where.index, ok = sw.fmap[where.field]; ok {
+				if where.index, ok = sw.fmap[where.field]; !ok {
 					where.index = math.MaxInt32
 				}
 				sw.wheres[i] = where
 			}
 		}
 		if len(whereins) > 0 {
-			sw.whereins = make([]whereinT, 0, len(whereins))
+			sw.whereins = make([]whereinT, len(whereins))
 			for i, wherein := range whereins {
-				if wherein.index, ok = sw.fmap[wherein.field]; ok {
+				if wherein.index, ok = sw.fmap[wherein.field]; !ok {
 					wherein.index = math.MaxInt32
 				}
 				sw.whereins[i] = wherein
@@ -231,7 +231,7 @@ func (sw *scanWriter) fieldMatch(fields []float64, o geojson.Object) (fvals []fl
 				continue
 			}
 			var value float64
-			if len(fields) > where.index {
+			if where.index < len(fields) {
 				value = fields[where.index]
 			}
 			if !where.match(value) {
@@ -240,7 +240,7 @@ func (sw *scanWriter) fieldMatch(fields []float64, o geojson.Object) (fvals []fl
 		}
 		for _, wherein := range sw.whereins {
 			var value float64
-			if len(fields) > wherein.index {
+			if wherein.index < len(fields) {
 				value = fields[wherein.index]
 			}
 			if !wherein.match(value) {

--- a/internal/server/scanner.go
+++ b/internal/server/scanner.go
@@ -120,18 +120,20 @@ func (s *Server) newScanWriter(
 		var ok bool
 		if len(wheres) > 0 {
 			sw.wheres = make([]whereT, 0, len(wheres))
-			for _, where := range wheres {
+			for i, where := range wheres {
 				if where.index, ok = sw.fmap[where.field]; ok {
-					sw.wheres = append(sw.wheres, where)
+					where.index = math.MaxInt32
 				}
+				sw.wheres[i] = where
 			}
 		}
 		if len(whereins) > 0 {
 			sw.whereins = make([]whereinT, 0, len(whereins))
-			for _, wherein := range whereins {
+			for i, wherein := range whereins {
 				if wherein.index, ok = sw.fmap[wherein.field]; ok {
-					sw.whereins = append(sw.whereins, wherein)
+					wherein.index = math.MaxInt32
 				}
+				sw.whereins[i] = wherein
 			}
 		}
 	}
@@ -276,13 +278,19 @@ func (sw *scanWriter) fieldMatch(fields []float64, o geojson.Object) (fvals []fl
 				}
 				continue
 			}
-			value := sw.fvals[where.index]
+			var value float64
+			if where.index < len(sw.fvals) {
+				value = sw.fvals[where.index]
+			}
 			if !where.match(value) {
 				return
 			}
 		}
 		for _, wherein := range sw.whereins {
-			value := sw.fvals[wherein.index]
+			var value float64
+			if wherein.index < len(sw.fvals) {
+				value = sw.fvals[wherein.index]
+			}
 			if !wherein.match(value) {
 				return
 			}

--- a/internal/server/scanner.go
+++ b/internal/server/scanner.go
@@ -118,14 +118,20 @@ func (s *Server) newScanWriter(
 		// This fills index value in wheres/whereins
 		// so we don't have to map string field names for each tested object
 		var ok bool
-		for _, where := range wheres {
-			if where.index, ok = sw.fmap[where.field]; ok {
-				sw.wheres = append(sw.wheres, where)
+		if len(wheres) > 0 {
+			sw.wheres = make([]whereT, 0, len(wheres))
+			for _, where := range wheres {
+				if where.index, ok = sw.fmap[where.field]; ok {
+					sw.wheres = append(sw.wheres, where)
+				}
 			}
 		}
-		for _, wherein := range whereins {
-			if wherein.index, ok = sw.fmap[wherein.field]; ok {
-				sw.whereins = append(sw.whereins, wherein)
+		if len(whereins) > 0 {
+			sw.whereins = make([]whereinT, 0, len(whereins))
+			for _, wherein := range whereins {
+				if wherein.index, ok = sw.fmap[wherein.field]; ok {
+					sw.whereins = append(sw.whereins, wherein)
+				}
 			}
 		}
 	}

--- a/internal/server/scanner_test.go
+++ b/internal/server/scanner_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/tidwall/geojson"
+	"github.com/tidwall/geojson/geometry"
+)
+
+type testPointItem struct {
+	object geojson.Object
+	fields []float64
+}
+
+func PO(x, y float64) *geojson.Point {
+	return geojson.NewPoint(geometry.Point{X: x, Y: y})
+}
+
+
+func BenchmarkFieldMatch(t *testing.B) {
+	rand.Seed(time.Now().UnixNano())
+	items := make([]testPointItem, t.N)
+	for i := 0; i < t.N; i++ {
+		items[i] = testPointItem{
+			PO(rand.Float64()*360-180, rand.Float64()*180-90),
+			[]float64{rand.Float64()*9+1, math.Round(rand.Float64()*30) + 1},
+		}
+	}
+	sw := &scanWriter{
+		wheres: []whereT{
+			{"foo", false, 1, false, 3},
+			{"bar", false, 10, false, 30},
+		},
+		whereins: []whereinT{
+			{"foo", map[float64]struct{}{1: {}, 2: {}}},
+			{"bar", map[float64]struct{}{11: {}, 25: {}}},
+		},
+		fmap: map[string]int{"foo": 0, "bar": 1},
+		farr: []string{"bar", "foo"},
+	}
+	sw.fvals = make([]float64, len(sw.farr))
+	t.ResetTimer()
+	for i := 0; i < t.N; i++ {
+		// one call is super fast, measurements are not reliable, let's do 100
+		for ix := 0; ix < 100; ix++ {
+			sw.fieldMatch(items[i].fields, items[i].object)
+		}
+	}
+}

--- a/internal/server/scanner_test.go
+++ b/internal/server/scanner_test.go
@@ -31,12 +31,12 @@ func BenchmarkFieldMatch(t *testing.B) {
 	}
 	sw := &scanWriter{
 		wheres: []whereT{
-			{"foo", false, 1, false, 3},
-			{"bar", false, 10, false, 30},
+			{"foo", 0, false, 1, false, 3},
+			{"bar", 1, false, 10, false, 30},
 		},
 		whereins: []whereinT{
-			{"foo", []float64{1, 2}},
-			{"bar", []float64{11, 25}},
+			{"foo", 0, []float64{1, 2}},
+			{"bar", 1, []float64{11, 25}},
 		},
 		fmap: map[string]int{"foo": 0, "bar": 1},
 		farr: []string{"bar", "foo"},

--- a/internal/server/scanner_test.go
+++ b/internal/server/scanner_test.go
@@ -35,8 +35,8 @@ func BenchmarkFieldMatch(t *testing.B) {
 			{"bar", false, 10, false, 30},
 		},
 		whereins: []whereinT{
-			{"foo", map[float64]struct{}{1: {}, 2: {}}},
-			{"bar", map[float64]struct{}{11: {}, 25: {}}},
+			{"foo", []float64{1, 2}},
+			{"bar", []float64{11, 25}},
 		},
 		fmap: map[string]int{"foo": 0, "bar": 1},
 		farr: []string{"bar", "foo"},

--- a/internal/server/token.go
+++ b/internal/server/token.go
@@ -159,12 +159,16 @@ func zMinMaxFromWheres(wheres []whereT) (minZ, maxZ float64) {
 
 type whereinT struct {
 	field  string
-	valMap map[float64]struct{}
+	valArr []float64
 }
 
 func (wherein whereinT) match(value float64) bool {
-	_, ok := wherein.valMap[value]
-	return ok
+	for _, val := range wherein.valArr {
+		if val == value {
+			return true
+		}
+	}
+	return false
 }
 
 type whereevalT struct {
@@ -342,9 +346,8 @@ func (s *Server) parseSearchScanBaseTokens(
 					err = errInvalidArgument(nvalsStr)
 					return
 				}
-				valMap := make(map[float64]struct{})
+				valArr := make([]float64, nvals)
 				var val float64
-				var empty struct{}
 				for i = 0; i < nvals; i++ {
 					if vs, valStr, ok = tokenval(vs); !ok || valStr == "" {
 						err = errInvalidNumberOfArguments
@@ -354,9 +357,9 @@ func (s *Server) parseSearchScanBaseTokens(
 						err = errInvalidArgument(valStr)
 						return
 					}
-					valMap[val] = empty
+					valArr = append(valArr, val)
 				}
-				t.whereins = append(t.whereins, whereinT{field, valMap})
+				t.whereins = append(t.whereins, whereinT{field, valArr})
 				continue
 			case "whereevalsha":
 				fallthrough

--- a/internal/server/token.go
+++ b/internal/server/token.go
@@ -116,6 +116,7 @@ func lc(s1, s2 string) bool {
 
 type whereT struct {
 	field string
+	index int
 	minx  bool
 	min   float64
 	maxx  bool
@@ -159,6 +160,7 @@ func zMinMaxFromWheres(wheres []whereT) (minZ, maxZ float64) {
 
 type whereinT struct {
 	field  string
+	index  int
 	valArr []float64
 }
 
@@ -328,7 +330,7 @@ func (s *Server) parseSearchScanBaseTokens(
 						return
 					}
 				}
-				t.wheres = append(t.wheres, whereT{field, minx, min, maxx, max})
+				t.wheres = append(t.wheres, whereT{field, -1, minx, min, maxx, max})
 				continue
 			case "wherein":
 				vs = nvs
@@ -359,7 +361,7 @@ func (s *Server) parseSearchScanBaseTokens(
 					}
 					valArr = append(valArr, val)
 				}
-				t.whereins = append(t.whereins, whereinT{field, valArr})
+				t.whereins = append(t.whereins, whereinT{field, -1, valArr})
 				continue
 			case "whereevalsha":
 				fallthrough

--- a/internal/server/token.go
+++ b/internal/server/token.go
@@ -359,7 +359,7 @@ func (s *Server) parseSearchScanBaseTokens(
 						err = errInvalidArgument(valStr)
 						return
 					}
-					valArr = append(valArr, val)
+					valArr[i] = val
 				}
 				t.whereins = append(t.whereins, whereinT{field, -1, valArr})
 				continue

--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -394,6 +394,9 @@ func keys_WHEREIN_test(mc *mockServer) error {
 		{"SET", "mykey", "myid_a2", "FIELD", "a", 2, "POINT", 32.99, -115}, {"OK"},
 		{"SET", "mykey", "myid_a3", "FIELD", "a", 3, "POINT", 33, -115.02}, {"OK"},
 		{"WITHIN", "mykey", "WHEREIN", "a", 3, 0, 1, 2, "BOUNDS", 32.8, -115.2, 33.2, -114.8}, {`[0 [[myid_a1 {"type":"Point","coordinates":[-115,33]} [a 1]] [myid_a2 {"type":"Point","coordinates":[-115,32.99]} [a 2]]]]`},
+		// zero value should not match 1 and 2
+		{"SET", "mykey", "myid_a0", "FIELD", "a", 0, "POINT", 33, -115.02}, {"OK"},
+		{"WITHIN", "mykey", "WHEREIN", "a", 2, 1, 2, "BOUNDS", 32.8, -115.2, 33.2, -114.8}, {`[0 [[myid_a1 {"type":"Point","coordinates":[-115,33]} [a 1]] [myid_a2 {"type":"Point","coordinates":[-115,32.99]} [a 2]]]]`},
 	})
 }
 


### PR DESCRIPTION
The following optimizations were made:
* use copy() instead of a loop for copying array values;
* use array of values instead of a map for whereins;
* map the field names to index values once per-query, not per point.

The benchmark shows improvement (had to time 100 calls to have reliable data):
```
 name          old time/op    new time/op    delta
FieldMatch-4    2.69µs ± 3%    1.53µs ± 5%  -43.02%  (p=0.000 n=9+10)
```