### PR TITLE
Add CLIPBY subcommand to INTERSECTS/WITHIN

### DIFF
--- a/internal/server/token.go
+++ b/internal/server/token.go
@@ -18,6 +18,7 @@ var errIDNotFound = errors.New("id not found")
 var errIDAlreadyExists = errors.New("id already exists")
 var errPathNotFound = errors.New("path not found")
 var errKeyHasHooksSet = errors.New("key has hooks set")
+var errNotRectangle = errors.New("not a rectangle")
 
 func errInvalidArgument(arg string) error {
 	return fmt.Errorf("invalid argument '%s'", arg)


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
A common use case for us is searching within a complicated polygon like a large city, modulo a couple of rectangular windows, e.g. tile and the users's viewport, could be others.  Essentially, we need to search within a polygon clipped by those windows.  The polygon is a complicated and its geojson is a lot of bytes to send, but since we know all these complicated shapes we already store them in a special collection within tile38. Without clipping we could have used `WITHIN collection GET place place_id`.  However, because we need to clip the known polygon by the user-defined window we can't do that.

**Describe the solution you'd like**
I propose:
* extending the spatial search commands (`NEARBY`, `WITHIN`, `INTERSECTS`) with the new subcommand `CLIPBY <clip_area> [CLIPBY <clip_area> [...] ]`. 
* there could be more than one `CLIPBY`.
* each `<clip_area>` can only be a rectangle: bbox, tile, hash, quadkey.
* each `CLIPBY <clip_area>` clause clips the specified area by that rectangle.
* the search is then performed on the resulting clipped area.
With this, our use case is simplified to `WITHIN collection GET place place_id CLIPBY bounds 1 2 3 4` or similarly with the tile.

**Describe alternatives you've considered**
 What we have to do instead is clip the shape on the client and send the geojson, meaning a very large query, in terms of bytes sent.

**Additional context**
This PR implements the proposed extension.  We had it tested.