### PR TITLE
Fix crash in fenceMatchRoam causing an index out of range panic

### DIFF
--- a/internal/server/fence.go
+++ b/internal/server/fence.go
@@ -410,7 +410,7 @@ func fenceMatchRoam(
 		var match bool
 		var j int
 		for ; j < len(newNearbys); j++ {
-			if newNearbys[i].id == oldNearbys[i].id {
+			if newNearbys[j].id == oldNearbys[i].id {
 				match = true
 				break
 			}


### PR DESCRIPTION
Stack trace when tiles38-server crashed:
```
panic: runtime error: index out of range [1] with length 1

goroutine 19 [running]:
github.com/tidwall/tile38/internal/server.fenceMatchRoam(0xc0000b0a00, 0xc00020d180, 0xc00027c340, 0x7, 0xedf880, 0xc0004ef020, 0xedf880, 0xc000155b20, 0xedf880, 0xc00049d660, ...)
	/home/larsw/go/src/github.com/larsw/tile38/internal/server/fence.go:413 +0x4f8
github.com/tidwall/tile38/internal/server.fenceMatch(0x0, 0x0, 0xc0001d7380, 0xc00020d180, 0x0, 0x0, 0x0, 0xc00015cb40, 0xc0005519c8, 0x4e1141, ...)
	/home/larsw/go/src/github.com/larsw/tile38/internal/server/fence.go:100 +0x15e1
github.com/tidwall/tile38/internal/server.FenceMatch(0x0, 0x0, 0xc0001d7380, 0xc00020d180, 0x0, 0x0, 0x0, 0xc00015cb40, 0x4806c3, 0xc00027c700, ...)
	/home/larsw/go/src/github.com/larsw/tile38/internal/server/fence.go:18 +0x9b
github.com/tidwall/tile38/internal/server.(*Server).goLive.func4(0xc0000b0a00, 0xc000551bd0, 0xc00020d180, 0xc00015cb40, 0xc000551c40)
	/home/larsw/go/src/github.com/larsw/tile38/internal/server/live.go:190 +0xaf
github.com/tidwall/tile38/internal/server.(*Server).goLive(0xc0000b0a00, 0xec1f00, 0xc00020d040, 0xedbaa0, 0xc0002f85a0, 0xc000500040, 0xc000204870, 0x0, 0x0, 0x0)
	/home/larsw/go/src/github.com/larsw/tile38/internal/server/live.go:191 +0x9f7
github.com/tidwall/tile38/internal/server.(*Server).netServe.func1.2(0xc00027c6d0, 0xc0000b0a00, 0xc000500000, 0xedbc80, 0xc00000e330, 0x7fc7da96a318, 0xc00000e330)
	/home/larsw/go/src/github.com/larsw/tile38/internal/server/server.go:438 +0x153
created by github.com/tidwall/tile38/internal/server.(*Server).netServe.func1
	/home/larsw/go/src/github.com/larsw/tile38/internal/server/server.go:436 +0x1004
```

Test case used to find the bug:
terminal 1:
```
nearby coyotes fence roam coyotes * 5000 
```

terminal 2:
(pip install redis)
```python
import csv
from redis import Connection

conn = Connection(host='localhost', port=9851)

def insert(id, lat, lon):
    conn.send_command('SET', 'coyotes', id, 'POINT', lat, lon)
    conn.read_response()

f = open('data.csv')
reader = csv.reader(f)

reader.__next__() # skip header

for row in reader:
    date = row[2].split(' ')[0]
    lat = row[4]
    lon = row[3]
    id = row[10]
    print(f'[{date}] inserting for #{id} ({lat}, {lon})')
    insert(id, lat, lon)
```

Data set (renamed to data.csv) https://www.datarepository.movebank.org/handle/10255/move.970