### PR TITLE
add kafka tls config

### DIFF
--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -61,9 +61,13 @@ type Endpoint struct {
 		Channel string
 	}
 	Kafka struct {
-		Host      string
-		Port      int
-		TopicName string
+		Host       string
+		Port       int
+		TopicName  string
+		TLS        bool
+		CACertFile string
+		CertFile   string
+		KeyFile    string
 	}
 	AMQP struct {
 		URI          string
@@ -387,6 +391,29 @@ func parseEndpoint(s string) (Endpoint, error) {
 		// Throw error if we not provide any queue name
 		if endpoint.Kafka.TopicName == "" {
 			return endpoint, errors.New("missing kafka topic name")
+		}
+
+		// Parsing additional params
+		if len(sqp) > 1 {
+			m, err := url.ParseQuery(sqp[1])
+			if err != nil {
+				return endpoint, errors.New("invalid kafka url")
+			}
+			for key, val := range m {
+				if len(val) == 0 {
+					continue
+				}
+				switch key {
+				case "tls":
+					endpoint.Kafka.TLS, _ = strconv.ParseBool(val[0])
+				case "cacert":
+					endpoint.Kafka.CACertFile = val[0]
+				case "cert":
+					endpoint.Kafka.CertFile = val[0]
+				case "key":
+					endpoint.Kafka.KeyFile = val[0]
+				}
+			}
 		}
 	}
 

--- a/internal/endpoint/kafka.go
+++ b/internal/endpoint/kafka.go
@@ -1,13 +1,20 @@
 package endpoint
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
+	lg "log"
+
 	"github.com/Shopify/sarama"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/tile38/internal/log"
 )
 
 const kafkaExpiresAfter = time.Second * 30
@@ -53,9 +60,25 @@ func (conn *KafkaConn) Send(msg string) error {
 	}
 	conn.t = time.Now()
 
+	if log.Level > 2 {
+		sarama.Logger = lg.New(os.Stdout, "[sarama] ", lg.LstdFlags)
+	}
+
 	uri := fmt.Sprintf("%s:%d", conn.ep.Kafka.Host, conn.ep.Kafka.Port)
 	if conn.conn == nil {
 		cfg := sarama.NewConfig()
+		cfg.ClientID = "Tile38" // otherwise defaults to sarama
+
+		if conn.ep.Kafka.TLS {
+			log.Debugf("building kafka tls config")
+			tlsConfig, err := newKafkaTLSConfig(conn.ep.Kafka.CertFile, conn.ep.Kafka.KeyFile, conn.ep.Kafka.CACertFile)
+			if err != nil {
+				return err
+			}
+			cfg.Net.TLS.Enable = true
+			cfg.Net.TLS.Config = tlsConfig
+		}
+
 		cfg.Net.DialTimeout = time.Second
 		cfg.Net.ReadTimeout = time.Second * 5
 		cfg.Net.WriteTimeout = time.Second * 5
@@ -101,4 +124,27 @@ func newKafkaConn(ep Endpoint) *KafkaConn {
 		ep: ep,
 		t:  time.Now(),
 	}
+}
+
+func newKafkaTLSConfig(CertFile, KeyFile, CACertFile string) (*tls.Config, error) {
+	tlsConfig := tls.Config{}
+
+	// Load client cert
+	cert, err := tls.LoadX509KeyPair(CertFile, KeyFile)
+	if err != nil {
+		return &tlsConfig, err
+	}
+	tlsConfig.Certificates = []tls.Certificate{cert}
+
+	// Load CA cert
+	caCert, err := ioutil.ReadFile(CACertFile)
+	if err != nil {
+		return &tlsConfig, err
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+	tlsConfig.RootCAs = caCertPool
+
+	tlsConfig.BuildNameToCertificate()
+	return &tlsConfig, err
 }

--- a/internal/endpoint/kafka.go
+++ b/internal/endpoint/kafka.go
@@ -67,7 +67,6 @@ func (conn *KafkaConn) Send(msg string) error {
 	uri := fmt.Sprintf("%s:%d", conn.ep.Kafka.Host, conn.ep.Kafka.Port)
 	if conn.conn == nil {
 		cfg := sarama.NewConfig()
-		cfg.ClientID = "Tile38" // otherwise defaults to sarama
 
 		if conn.ep.Kafka.TLS {
 			log.Debugf("building kafka tls config")


### PR DESCRIPTION
As [discussed](https://tile38.slack.com/archives/C0M6QN8VC/p1613396062034300), I added the option to enable TLS on the kafka endpoints and allowing to pass the required certificates similar to your `mqtt` approach.

As a failed connection due to false certificates does not show up in your Kafka broker, I added the option to debug TLS through saramas logger. I would love to make it work in the similar schema as your logging, but I frankly don't know how I would be doing that.

For easier debugging I also opted to use a different sarama.ClientID as the current default value of `sarama`. 

To reproduce my test environment you can create your keystore and truststore following this [bash script](https://github.com/confluentinc/cp-docker-images/blob/5.2.1-post/examples/kafka-cluster-ssl/secrets/create-certs.sh) from confluent but editing the `CN` to `localhost` where applicable.

Copy the `kafka.broker1.truststore.jks` and the `kafka.broker1.keystore.jks` in a different folder.

and extract a `cert` `key` and `cacert` file via

```
keytool -importkeystore -srckeystore kafka.server.truststore.jks -destkeystore server.p12 -deststoretype PKCS12
openssl pkcs12 -in server.p12 -nokeys -out server.cer.pem
```

```
keytool -importkeystore -srckeystore kafka.broker1.keystore.jks -destkeystore client.p12 -deststoretype PKCS12
openssl pkcs12 -in client.p12 -nokeys -out client.cer.pem
openssl pkcs12 -in client.p12 -nodes -nocerts -out client.key.pem
```

As for the kafka infra I used:

```
version: "3"

services:
  zookeeper:
    image: wurstmeister/zookeeper:latest
    container_name: zookeeper
    ports:
      - "2181:2181"

  kafka:
    image: wurstmeister/kafka:2.11-1.1.1
    ports:
      - "9092:9092"
      - "9093:9093"
    links:
      - zookeeper
    environment:
      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,SSL://localhost:9093
      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,SSL://0.0.0.0:9093
      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
      KAFKA_DELETE_TOPIC_ENABLE: "true"
      KAFKA_SSL_KEYSTORE_LOCATION: '/certs/kafka.broker1.keystore.jks'
      KAFKA_SSL_KEYSTORE_PASSWORD: 'confluent'
      KAFKA_SSL_KEY_PASSWORD: 'confluent'
      KAFKA_SSL_TRUSTSTORE_LOCATION: '/certs/kafka.broker1.truststore.jks'
      KAFKA_SSL_TRUSTSTORE_PASSWORD: 'confluent'
      KAFKA_SSL_CLIENT_AUTH: 'none'
      KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: ''
      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: 'SSL'
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - ../../your_certs:/certs
```

After that you start `tile38-cli` and `tile38-server -vv` and use

```
SETHOOK warehouse kafka://localhost:9093/warehouse?tls=true&cert=certs/client.cer.pem&key=certs/client.key.pem&cacert=certs/server.cer.pem NEARBY fleet FENCE POINT 33.5123 -112.2693 500
```

and

```
SET fleet bus POINT 33.5123 -112.2693
```