### PR TITLE
fix: return distance if point and object have the same coordinates

### DIFF
--- a/internal/server/fence.go
+++ b/internal/server/fence.go
@@ -164,9 +164,12 @@ func fenceMatch(
 		break
 	}
 	sw.mu.Lock()
-	var distance float64
+	var meters float64
+	distance := Distance{false, meters}
 	if fence.distance && fence.obj != nil {
-		distance = details.obj.Distance(fence.obj)
+		meters = details.obj.Distance(fence.obj)
+		distance.ready = true
+		distance.meters = meters
 	}
 	sw.fmap = details.fmap
 	sw.fullFields = true

--- a/internal/server/scanner.go
+++ b/internal/server/scanner.go
@@ -60,12 +60,18 @@ type scanWriter struct {
 	respOut        resp.Value
 }
 
+// Distance ...
+type Distance struct {
+	ready  bool
+	meters float64
+}
+
 // ScanWriterParams ...
 type ScanWriterParams struct {
 	id              string
 	o               geojson.Object
 	fields          []float64
-	distance        float64
+	distance        Distance
 	noLock          bool
 	ignoreGlobMatch bool
 	clip            geojson.Object
@@ -433,8 +439,8 @@ func (sw *scanWriter) writeObject(opts ScanWriterParams) bool {
 
 			wr.WriteString(jsfields)
 
-			if opts.distance > 0 {
-				wr.WriteString(`,"distance":` + strconv.FormatFloat(opts.distance, 'f', -1, 64))
+			if opts.distance.ready {
+				wr.WriteString(`,"distance":` + strconv.FormatFloat(opts.distance.meters, 'f', -1, 64))
 			}
 
 			wr.WriteString(`}`)
@@ -496,8 +502,8 @@ func (sw *scanWriter) writeObject(opts ScanWriterParams) bool {
 					vals = append(vals, resp.ArrayValue(fvals))
 				}
 			}
-			if opts.distance > 0 {
-				vals = append(vals, resp.FloatValue(opts.distance))
+			if opts.distance.ready {
+				vals = append(vals, resp.FloatValue(opts.distance.meters))
 			}
 
 			sw.values = append(sw.values, resp.ArrayValue(vals))

--- a/internal/server/search.go
+++ b/internal/server/search.go
@@ -372,14 +372,18 @@ func (server *Server) cmdNearby(msg *Message) (res resp.Value, err error) {
 	if sw.col != nil {
 		iter := func(id string, o geojson.Object, fields []float64, dist float64) bool {
 			meters := 0.0
+			distance := Distance{false, meters}
+
 			if s.distance {
 				meters = geo.DistanceFromHaversine(dist)
+				distance.ready = true
+				distance.meters = meters
 			}
 			return sw.writeObject(ScanWriterParams{
 				id:              id,
 				o:               o,
 				fields:          fields,
-				distance:        meters,
+				distance:        distance,
 				noLock:          true,
 				ignoreGlobMatch: true,
 				skipTesting:     true,

--- a/tests/keys_search_test.go
+++ b/tests/keys_search_test.go
@@ -28,10 +28,13 @@ func keys_KNN_test(mc *mockServer) error {
 		{"SET", "mykey", "3", "POINT", 12, 19}, {"OK"},
 		{"SET", "mykey", "4", "POINT", -5, 5}, {"OK"},
 		{"SET", "mykey", "5", "POINT", 33, 21}, {"OK"},
+		{"SET", "mykey", "6", "POINT", 52, 13}, {"OK"},
 		{"NEARBY", "mykey", "LIMIT", 10, "POINTS", "POINT", 20, 20}, {
-			"[0 [[2 [19 19]] [3 [12 19]] [5 [33 21]] [1 [5 5]] [4 [-5 5]]]]"},
-		{"NEARBY", "mykey", "LIMIT", 10, "IDS", "POINT", 20, 20, 4000000}, {"[0 [2 3 5 1 4]]"},
+			"[0 [[2 [19 19]] [3 [12 19]] [5 [33 21]] [1 [5 5]] [4 [-5 5]] [6 [52 13]]]]"},
+		{"NEARBY", "mykey", "LIMIT", 10, "IDS", "POINT", 20, 20, 4000000}, {"[0 [2 3 5 1 4 6]]"},
 		{"NEARBY", "mykey", "LIMIT", 10, "IDS", "POINT", 20, 20, 1500000}, {"[0 [2 3 5]]"},
+		{"NEARBY", "mykey", "LIMIT", 10, "DISTANCE", "POINT", 52, 13, 100}, {`[0 [[6 {"type":"Point","coordinates":[13,52]} 0]]]`},
+		{"NEARBY", "mykey", "LIMIT", 10, "DISTANCE", "POINT", 52.1, 13.1, 100000}, {`[0 [[6 {"type":"Point","coordinates":[13,52]} 13053.885940801563]]]`},
 	})
 }
 


### PR DESCRIPTION
addressing #599 

Now correctly shows distance in response, if point and object share the same coordinates without affecting `writeObject` return value for other searches.

For this to work I had to introduce a new type `Distance` whos `ready` property is only set in a nearby search. This way I can check its state in `writeObject` and will only append `distance` when it's `ready: true`.

I also added tests, to make sure it behaves as planned and does no affect the other searches and fences.

wdyt? 