### PR TITLE
amqp: removal of queue and binding creation

### DIFF
--- a/internal/endpoint/amqp.go
+++ b/internal/endpoint/amqp.go
@@ -85,30 +85,7 @@ func (conn *AMQPConn) Send(msg string) error {
 		); err != nil {
 			return err
 		}
-
-		// Create queue if queue don't exists
-		if _, err := channel.QueueDeclare(
-			conn.ep.AMQP.QueueName,
-			conn.ep.AMQP.Durable,
-			conn.ep.AMQP.AutoDelete,
-			false,
-			conn.ep.AMQP.NoWait,
-			nil,
-		); err != nil {
-			return err
-		}
-
-		// Binding exchange to queue
-		if err := channel.QueueBind(
-			conn.ep.AMQP.QueueName,
-			conn.ep.AMQP.RouteKey,
-			conn.ep.AMQP.QueueName,
-			conn.ep.AMQP.NoWait,
-			nil,
-		); err != nil {
-			return err
-		}
-
+		
 		conn.conn = c
 		conn.channel = channel
 	}


### PR DESCRIPTION
Consuming application is responsible for queue creation and its bindings.