### PR TITLE
kafka authentication methods

### DIFF
--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -66,10 +66,10 @@ type Endpoint struct {
 		Host       string
 		Port       int
 		TopicName  string
-		SASL       bool
+		Auth       string
+		SSL        bool
 		SASLSHA256 bool
 		SASLSHA512 bool
-		TLS        bool
 		CACertFile string
 		CertFile   string
 		KeyFile    string
@@ -422,16 +422,16 @@ func parseEndpoint(s string) (Endpoint, error) {
 					continue
 				}
 				switch key {
-				case "tls":
-					endpoint.Kafka.TLS, _ = strconv.ParseBool(val[0])
+				case "auth":
+					endpoint.Kafka.Auth = val[0]
+				case "ssl":
+					endpoint.Kafka.SSL, _ = strconv.ParseBool(val[0])
 				case "cacert":
 					endpoint.Kafka.CACertFile = val[0]
 				case "cert":
 					endpoint.Kafka.CertFile = val[0]
 				case "key":
 					endpoint.Kafka.KeyFile = val[0]
-				case "sasl":
-					endpoint.Kafka.SASL, _ = strconv.ParseBool(val[0])
 				case "sha256":
 					endpoint.Kafka.SASLSHA256, _ = strconv.ParseBool(val[0])
 				case "sha512":


### PR DESCRIPTION
Hi! 👋 

in #615 we added authentication with SASL and shortly after the release I noticed that we did take care of the authentication but forgot about SSL in the process. As a result SASL authentication currently does only work if the connection to the broker is not encrypted (SASL PLAIN). This is because Tile38 does not allow for the verification to be skipped in the sarama config. 

I created an example for the case at [iwpnd/tile-kafka-sasl](https://github.com/iwpnd/tile38-kafka-sasl) and tested SASL auth without SSL successfully.

Now with this PR I want to fix this introducing a new auth flow to support TLS, SASL, SASL/SSL and no-auth as follows:

![tile38-kafka-config](https://user-images.githubusercontent.com/6152183/128019801-9f1333b2-c536-4ed7-a4bb-aba4477df16a.jpg)

**SASL PLAIN**
`?auth=sasl&sha512=true` is using using credentials from the env `KAFKA_PASSWORD` / `KAFKA_USERNAME`

**SASL/SSL**
`?auth=sasl&ssl=true&sha512=true&cacert=/path/to/cert` is is using using credentials from the env `KAFKA_PASSWORD` / `KAFKA_USERNAME`. This now also validates the given root certificate accordingly.

**TLS**
`?auth=tls&cacert=/path/to/cacert&cert=/path/to/user.crt&key=/path/to/user.key` works as it had before #615. As TLS authenfication requires SSL, the additional `ssl=true` is obsolete and will be ignored.

Additional authentication methods can now be added as they're needed (SASL GSSAPI, PLAIN).

SASL/SSL has now been tested in a production environment with this fork [iwpnd/ben38](https://hub.docker.com/repository/docker/iwpnd/ben38) successfully. 

What do you think?