### PR TITLE
Upgrade alpine in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.15
 RUN apk add --no-cache ca-certificates
 
 ADD tile38-server /usr/local/bin


### PR DESCRIPTION
Use a more current version of Alpine.
Version 3.8 is no longer supported by e.g. [Trivy](https://aquasecurity.github.io/trivy)