### PR TITLE
Issue #642 - Expose config and INFO response for slave_priority

### DIFF
--- a/internal/server/stats.go
+++ b/internal/server/stats.go
@@ -408,8 +408,8 @@ func (s *Server) writeInfoReplication(w *bytes.Buffer) {
 		fmt.Fprintf(w, "role:slave\r\n")
 		fmt.Fprintf(w, "master_host:%s\r\n", s.config.followHost())
 		fmt.Fprintf(w, "master_port:%v\r\n", s.config.followPort())
-		if s.config.slavePriority() >= 0 {
-			fmt.Fprintf(w, "slave_priority:%v\r\n", s.config.slavePriority())
+		if s.config.replicaPriority() >= 0 {
+			fmt.Fprintf(w, "slave_priority:%v\r\n", s.config.replicaPriority())
 		}
 	} else {
 		fmt.Fprintf(w, "role:master\r\n")

--- a/internal/server/stats.go
+++ b/internal/server/stats.go
@@ -408,6 +408,9 @@ func (s *Server) writeInfoReplication(w *bytes.Buffer) {
 		fmt.Fprintf(w, "role:slave\r\n")
 		fmt.Fprintf(w, "master_host:%s\r\n", s.config.followHost())
 		fmt.Fprintf(w, "master_port:%v\r\n", s.config.followPort())
+		if s.config.slavePriority() >= 0 {
+			fmt.Fprintf(w, "slave_priority:%v\r\n", s.config.slavePriority())
+		}
 	} else {
 		fmt.Fprintf(w, "role:master\r\n")
 		var i int


### PR DESCRIPTION
PR for enhancement: https://github.com/tidwall/tile38/issues/642

Allow setting slave_priority in the config to any integer value greater than or equal to zero.
Zero means the slave will never be promoted to master(leader), and any other positive numeric value will be used as the priority order for Sentinel slave election when the master goes down.

If not specified the default priority of a slave is 100. If a negative number is specified then slave_priority will not be output in the INFO response and that slave will be considered to have the default priority value of 100.