### PR TITLE
Prevent certain Lua modules/functions from loading

### DIFF
--- a/internal/server/scripts.go
+++ b/internal/server/scripts.go
@@ -27,7 +27,7 @@ const (
 )
 
 // For Lua os.clock() impl
-var startedAt time.Time = time.Now()
+var startedAt = time.Now()
 
 var errShaNotFound = errors.New("sha not found")
 var errCmdNotSupported = errors.New("command not supported in scripts")

--- a/internal/server/scripts.go
+++ b/internal/server/scripts.go
@@ -105,7 +105,6 @@ func (pl *lStatePool) New() *lua.LState {
 		moduleName string
 		moduleFn   lua.LGFunction
 	}{
-		{lua.LoadLibName, lua.OpenPackage},
 		{lua.BaseLibName, openBaseSubset},
 		{lua.TabLibName, lua.OpenTable},
 		{lua.MathLibName, lua.OpenMath},
@@ -123,9 +122,6 @@ func (pl *lStatePool) New() *lua.LState {
 			panic(err)
 		}
 	}
-
-	// Set package module to Nil so loaders can't be accessed
-	L.SetGlobal("package", lua.LNil)
 
 	getArgs := func(ls *lua.LState) (evalCmd string, args []string) {
 		evalCmd = ls.GetGlobal("EVAL_CMD").String()

--- a/internal/server/scripts.go
+++ b/internal/server/scripts.go
@@ -27,7 +27,7 @@ const (
 )
 
 // For Lua os.clock() impl
-var startedAt time.Time
+var startedAt time.Time = time.Now()
 
 var errShaNotFound = errors.New("sha not found")
 var errCmdNotSupported = errors.New("command not supported in scripts")
@@ -43,10 +43,6 @@ type lStatePool struct {
 	s     *Server
 	saved []*lua.LState
 	total int
-}
-
-func init() {
-	startedAt = time.Now()
 }
 
 // newPool returns a new pool of lua states
@@ -913,7 +909,7 @@ func baseToNumber(L *lua.LState) int {
 		L.Push(lv)
 	case lua.LString:
 		str := strings.Trim(string(lv), " \n\t")
-		if strings.Index(str, ".") > -1 {
+		if strings.Contains(str, ".") {
 			if v, err := strconv.ParseFloat(str, lua.LNumberBit); err != nil {
 				L.Push(lua.LNil)
 			} else {
@@ -944,7 +940,7 @@ func baseToString(L *lua.LState) int {
 
 // Lua os.clock()
 func osClock(L *lua.LState) int {
-	L.Push(lua.LNumber(float64(time.Now().Sub(startedAt)) / float64(time.Second)))
+	L.Push(lua.LNumber(time.Since(startedAt).Seconds()))
 	return 1
 }
 

--- a/internal/server/scripts.go
+++ b/internal/server/scripts.go
@@ -124,6 +124,9 @@ func (pl *lStatePool) New() *lua.LState {
 		}
 	}
 
+	// Set package module to Nil so loaders can't be accessed
+	L.SetGlobal("package", lua.LNil)
+
 	getArgs := func(ls *lua.LState) (evalCmd string, args []string) {
 		evalCmd = ls.GetGlobal("EVAL_CMD").String()
 

--- a/tests/scripts_test.go
+++ b/tests/scripts_test.go
@@ -71,6 +71,7 @@ func scripts_VULN_test(mc *mockServer) error {
 		{"EVAL", "return os.getenv", "0"}, {nil},
 		{"EVAL", "return os.clock", "0"}, {"ERR Unsupported lua type: function"},
 		{"EVAL", "return loadfile", "0"}, {nil},
-		{"EVAL", "return tonumber", "0"}, {"ERR Unsupported lua type: function"},
+		{"EVAL", "return tonumber(ARGV[1])", "0", "38"}, {"38"},
+		{"EVAL", "return package", "0"}, {nil},
 	})
 }

--- a/tests/scripts_test.go
+++ b/tests/scripts_test.go
@@ -10,6 +10,7 @@ func subTestScripts(g *testGroup) {
 	g.regSubTest("ATOMIC", scripts_ATOMIC_test)
 	g.regSubTest("READONLY", scripts_READONLY_test)
 	g.regSubTest("NONATOMIC", scripts_NONATOMIC_test)
+	g.regSubTest("VULN", scripts_VULN_test)
 }
 
 func scripts_BASIC_test(mc *mockServer) error {
@@ -59,5 +60,17 @@ func scripts_NONATOMIC_test(mc *mockServer) error {
 		{"EVALNA", "return tile38.call('get', KEYS[1], ARGV[1])", "1", "mykey", "myid"}, {nil},
 		{"EVALNA", "return tile38.call('set', KEYS[1], ARGV[1], 'point', 33, -115)", "1", "mykey", "myid1"}, {"OK"},
 		{"EVALNA", "return tile38.call('get', KEYS[1], ARGV[1], ARGV[2])", "1", "mykey", "myid1", "point"}, {"[33 -115]"},
+	})
+}
+
+func scripts_VULN_test(mc *mockServer) error {
+	return mc.DoBatch([][]interface{}{
+		{"EVAL", "return io", "0"}, {nil},
+		{"EVAL", "return file", "0"}, {nil},
+		{"EVAL", "return os.execute", "0"}, {nil},
+		{"EVAL", "return os.getenv", "0"}, {nil},
+		{"EVAL", "return os.clock", "0"}, {"ERR Unsupported lua type: function"},
+		{"EVAL", "return loadfile", "0"}, {nil},
+		{"EVAL", "return tonumber", "0"}, {"ERR Unsupported lua type: function"},
 	})
 }


### PR DESCRIPTION
This PR resolves #630.

## Changes:
- Modified `lua.NewState()` call to open **only** the following modules:
    * base\*
    * table
    * math
    * string
    * os\*
    > \* Only opens `base.tonumber()`, `base.tostring()`, `os.clock()`, and `os.difftime()`.
- Vendored internal Lua function implementations for the subset functions from `gopher-lua` (required to open the subsets, otherwise entire module is available).
- Added `scripts_VULN_tests` into `tests/scripts_test.go`; tests for function existence.

All tests pass using go version 1.19.3 on Linux.