### PR TITLE
Add graceful shutdown on SIGTERM

### DIFF
--- a/cmd/tile38-server/main.go
+++ b/cmd/tile38-server/main.go
@@ -413,6 +413,7 @@ Developer Options:
 	}
 
 	c := make(chan os.Signal, 1)
+	shutdown := make (chan bool, 1)
 
 	signal.Notify(c, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
@@ -433,7 +434,7 @@ Developer Options:
 			case s == syscall.SIGQUIT:
 				os.Exit(3)
 			case s == syscall.SIGTERM:
-				os.Exit(0xf)
+				shutdown <- true
 			}
 		}
 	}()
@@ -481,6 +482,7 @@ Developer Options:
 		AppendOnly:        appendOnly,
 		AppendFileName:    appendFileName,
 		QueueFileName:     queueFileName,
+		Shutdown:          shutdown,
 	}
 	if err := server.Serve(opts); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Graceful shutdown was implemented in this commit https://github.com/tidwall/tile38/commit/906824323b908790cdb7b3d26e80cd944536c5c7 but there is no way to trigger it from outside. This change makes SIGTERM trigger the graceful shutdown.