### PR TITLE
add hostname, port, output, and password env variables to tile38-cli

### DIFF
--- a/cmd/tile38-cli/main.go
+++ b/cmd/tile38-cli/main.go
@@ -22,6 +22,14 @@ import (
 	"github.com/tidwall/tile38/core"
 )
 
+func getEnv(name string, defaultValue string) string {
+	val, exists := os.LookupEnv(name)
+	if !exists {
+		return defaultValue
+	}
+	return val
+}
+
 func userHomeDir() string {
 	if runtime.GOOS == "windows" {
 		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
@@ -82,6 +90,17 @@ func parseArgs() bool {
 			}
 		}
 	}()
+
+	hostname = getEnv("TILE38_HOSTNAME", hostname)
+	output = getEnv("TILE38_OUTPUT", output)
+	portStr := getEnv("TILE38_PORT", "")
+
+	if portStr != "" {
+		tempPort, err := strconv.Atoi(portStr)
+		if err == nil {
+			port = tempPort
+		}
+	}
 
 	args := os.Args[1:]
 	readArg := func(arg string) string {
@@ -286,7 +305,15 @@ func main() {
 			f.Close()
 		}
 	}()
+
+	password := getEnv("TILE38_PASSWORD", "")
+
+	if conn != nil && password != "" {
+		conn.Do(fmt.Sprintf("auth %s", password))
+	}
+
 	for {
+
 		var command string
 		var err error
 		if oneCommand == "" {


### PR DESCRIPTION
add support to env variables for tile38-cli, including password.

especially useful when running on docker, connecting to a protected server