### PR TITLE
Enables cross platform building and pushing of docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,33 +2,34 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.19
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.19
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      - name: Test
+        run: make test
 
-    - name: Test
-      run: make test
+      - name: Package
+        run: make package
 
-    - name: Docker push
-      env:
-        DOCKER_LOGIN: tidwall
-        DOCKER_USER: tile38
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      run: ./scripts/docker-push.sh
+      - name: Docker push
+        env:
+          DOCKER_LOGIN: tidwall
+          DOCKER_USER: tile38
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: ./scripts/docker-push.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 FROM alpine:3.16.2
+
+ARG VERSION
+ARG TARGETOS
+ARG TARGETARCH
+
 RUN apk add --no-cache ca-certificates
 
-ADD tile38-server /usr/local/bin
-ADD tile38-cli /usr/local/bin
-ADD tile38-benchmark /usr/local/bin
+ADD packages/tile38-$VERSION-$TARGETOS-$TARGETARCH/tile38-server /usr/local/bin
+ADD packages/tile38-$VERSION-$TARGETOS-$TARGETARCH/tile38-cli /usr/local/bin
+ADD packages/tile38-$VERSION-$TARGETOS-$TARGETARCH/tile38-benchmark /usr/local/bin
 
 RUN addgroup -S tile38 && \
     adduser -S -G tile38 tile38 && \

--- a/scripts/docker-push.sh
+++ b/scripts/docker-push.sh
@@ -6,27 +6,24 @@ cd $(dirname "${BASH_SOURCE[0]}")/..
 # GIT_BRANCH is the current branch name
 export GIT_BRANCH=$(git branch --show-current)
 # GIT_VERSION - always the last verison number, like 1.12.1.
-export GIT_VERSION=$(git describe --tags --abbrev=0)  
+export GIT_VERSION=$(git describe --tags --abbrev=0)
 # GIT_COMMIT_SHORT - the short git commit number, like a718ef0.
 export GIT_COMMIT_SHORT=$(git rev-parse --short HEAD)
 # DOCKER_REPO - the base repository name to push the docker build to.
 export DOCKER_REPO=$DOCKER_USER/tile38
 
-docker images
-docker inspect $DOCKER_REPO:$GIT_COMMIT_SHORT
-
 if [ "$GIT_BRANCH" != "master" ]; then
 	echo "Not pushing, not on master"
 elif [ "$DOCKER_USER" == "" ]; then
-	echo "Not pushing, DOCKER_USER not set"	
+	echo "Not pushing, DOCKER_USER not set"
 	exit 1
 elif [ "$DOCKER_LOGIN" == "" ]; then
-	echo "Not pushing, DOCKER_LOGIN not set"	
+	echo "Not pushing, DOCKER_LOGIN not set"
 	exit 1
 elif [ "$DOCKER_PASSWORD" == "" ]; then
 	echo "Not pushing, DOCKER_PASSWORD not set"
 	exit 1
-else 
+else
 	# setup cross platform builder
 	# https://github.com/tonistiigi/binfmt
 	docker run --privileged --rm tonistiigi/binfmt --install all

--- a/scripts/docker-push.sh
+++ b/scripts/docker-push.sh
@@ -12,6 +12,9 @@ export GIT_COMMIT_SHORT=$(git rev-parse --short HEAD)
 # DOCKER_REPO - the base repository name to push the docker build to.
 export DOCKER_REPO=$DOCKER_USER/tile38
 
+docker images
+docker inspect $DOCKER_REPO:$GIT_COMMIT_SHORT
+
 if [ "$GIT_BRANCH" != "master" ]; then
 	echo "Not pushing, not on master"
 elif [ "$DOCKER_USER" == "" ]; then
@@ -24,19 +27,32 @@ elif [ "$DOCKER_PASSWORD" == "" ]; then
 	echo "Not pushing, DOCKER_PASSWORD not set"
 	exit 1
 else 
-	push(){
-		docker tag $DOCKER_REPO:$GIT_COMMIT_SHORT $DOCKER_REPO:$1
-		docker push $DOCKER_REPO:$1
-		echo "Pushed $DOCKER_REPO:$1"
-	}
+	# setup cross platform builder
+	# https://github.com/tonistiigi/binfmt
+	docker run --privileged --rm tonistiigi/binfmt --install all
+	docker buildx create --name multiarch --platform linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64,linux/386,linux/arm/v7 --use default
+
 	# docker login
 	echo $DOCKER_PASSWORD | docker login -u $DOCKER_LOGIN --password-stdin
-	# build the docker image
-	docker build -f Dockerfile -t $DOCKER_REPO:$GIT_COMMIT_SHORT .
 	if [ "$(curl -s https://hub.docker.com/v2/repositories/$DOCKER_REPO/tags/$GIT_VERSION/ | grep "digest")" == "" ]; then
-		# push the newest tag
-		push "$GIT_VERSION"
-		push "latest"
+		# build the docker image
+		docker buildx build \
+			-f Dockerfile \
+			--platform linux/arm64,linux/amd64 \
+			--build-arg VERSION=$GIT_VERSION \
+			--tag $DOCKER_REPO:$GIT_VERSION \
+			--tag $DOCKER_REPO:latest \
+			--tag $DOCKER_REPO:edge \
+			--push \
+			.
+	else
+		# build the docker image
+		docker buildx build \
+			-f Dockerfile \
+			--platform linux/arm64,linux/amd64 \
+			--build-arg VERSION=$GIT_VERSION \
+			--tag $DOCKER_REPO:edge \
+			--push \
+			.
 	fi
-	push "edge"
 fi

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -42,5 +42,3 @@ else
 	zip -r -q $bdir.zip $bdir
 fi
 
-# Remove build directory.
-rm -rf $bdir


### PR DESCRIPTION
Would fix #628.

I've tried to keep as close as possible to the current workflow.

I added the `make package` step to have the builds for the various platform ready. I removed the line that deletes the build folders from the package script so that those artefacts can be reused by the docker build.

Finally building and pushing the docker containers is moved in a single step as the containers must be pushed directly by the buildx build.

I hope this will work in one go. I already tested the build but moved it out of the `if` condition in the script as I did not have the docker hub credentials setup. 