### PR TITLE
only create AMQP queue and binfings for non-topic exchanges

### DIFF
--- a/internal/endpoint/amqp.go
+++ b/internal/endpoint/amqp.go
@@ -93,28 +93,29 @@ func (conn *AMQPConn) Send(msg string) error {
 		); err != nil {
 			return err
 		}
+                if conn.ep.AMQP.Type != "topic" {
+			// Create queue if queue don't exists
+			if _, err := channel.QueueDeclare(
+				conn.ep.AMQP.QueueName,
+				conn.ep.AMQP.Durable,
+				conn.ep.AMQP.AutoDelete,
+				false,
+				conn.ep.AMQP.NoWait,
+				nil,
+			); err != nil {
+				return err
+			}
 
-		// Create queue if queue don't exists
-		if _, err := channel.QueueDeclare(
-			conn.ep.AMQP.QueueName,
-			conn.ep.AMQP.Durable,
-			conn.ep.AMQP.AutoDelete,
-			false,
-			conn.ep.AMQP.NoWait,
-			nil,
-		); err != nil {
-			return err
-		}
-
-		// Binding exchange to queue
-		if err := channel.QueueBind(
-			conn.ep.AMQP.QueueName,
-			conn.ep.AMQP.RouteKey,
-			conn.ep.AMQP.QueueName,
-			conn.ep.AMQP.NoWait,
-			nil,
-		); err != nil {
-			return err
+			// Binding exchange to queue
+			if err := channel.QueueBind(
+				conn.ep.AMQP.QueueName,
+				conn.ep.AMQP.RouteKey,
+				conn.ep.AMQP.QueueName,
+				conn.ep.AMQP.NoWait,
+				nil,
+			); err != nil {
+				return err
+			}
 		}
 
 		conn.conn = c

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,12 +16,12 @@ if [ "$(which go)" == "" ]; then
 fi
 
 # Hardcode some values to the core package.
-if [ -d ".git" ]; then
-	VERSION=$(git describe --tags --abbrev=0)
-	GITSHA=$(git rev-parse --short HEAD)
-	LDFLAGS="$LDFLAGS -X github.com/tidwall/tile38/core.Version=${VERSION}"
-	LDFLAGS="$LDFLAGS -X github.com/tidwall/tile38/core.GitSHA=${GITSHA}"
-fi
+#if [ -d ".git" ]; then
+#	VERSION=$(git describe --tags --abbrev=0)
+#	GITSHA=$(git rev-parse --short HEAD)
+#	LDFLAGS="$LDFLAGS -X github.com/tidwall/tile38/core.Version=${VERSION}"
+#	LDFLAGS="$LDFLAGS -X github.com/tidwall/tile38/core.GitSHA=${GITSHA}"
+#fi
 LDFLAGS="$LDFLAGS -X github.com/tidwall/tile38/core.BuildTime=$(date +%FT%T%z)"
 
 # Generate the core package

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,12 +16,12 @@ if [ "$(which go)" == "" ]; then
 fi
 
 # Hardcode some values to the core package.
-#if [ -d ".git" ]; then
-#	VERSION=$(git describe --tags --abbrev=0)
-#	GITSHA=$(git rev-parse --short HEAD)
-#	LDFLAGS="$LDFLAGS -X github.com/tidwall/tile38/core.Version=${VERSION}"
-#	LDFLAGS="$LDFLAGS -X github.com/tidwall/tile38/core.GitSHA=${GITSHA}"
-#fi
+if [ -d ".git" ]; then
+	VERSION=$(git describe --tags --abbrev=0)
+	GITSHA=$(git rev-parse --short HEAD)
+	LDFLAGS="$LDFLAGS -X github.com/tidwall/tile38/core.Version=${VERSION}"
+	LDFLAGS="$LDFLAGS -X github.com/tidwall/tile38/core.GitSHA=${GITSHA}"
+fi
 LDFLAGS="$LDFLAGS -X github.com/tidwall/tile38/core.BuildTime=$(date +%FT%T%z)"
 
 # Generate the core package


### PR DESCRIPTION
as discussed in #606, under some circumstances queues and bindings under AMQP should not be created. Disabled this for type 'topic'.
Cheers
Uwe