### PR TITLE
[BUG] Fix AWS SQS base domain parsing for China region

### DIFF
--- a/internal/endpoint/sqs.go
+++ b/internal/endpoint/sqs.go
@@ -132,13 +132,13 @@ func newSQSConn(ep Endpoint) *SQSConn {
 func probeSQS(s string) bool {
 	// https://sqs.eu-central-1.amazonaws.com/123456789/myqueue
 	return strings.HasPrefix(s, "https://sqs.") &&
-		strings.Contains(s, ".amazonaws.com/")
+		strings.Contains(s, ".amazonaws.com")
 }
 
 func sqsRegionFromPlainURL(s string) string {
 	parts := strings.Split(s, "https://sqs.")
 	if len(parts) > 1 {
-		parts = strings.Split(parts[1], ".amazonaws.com/")
+		parts = strings.Split(parts[1], ".amazonaws.com")
 		if len(parts) > 1 {
 			return parts[0]
 		}


### PR DESCRIPTION
### Please ensure you adhere to every item in this list

- [x] This PR was pre-approved by the project maintainer
- [x] I have self-reviewed the code
- [x] I have added all necessary tests

### Describe your changes

For AWS China region base domain is slightly different than for the rest world. It is `amazon.com.cn`.
Currently AWS domain is hard coded in the `sqs.go`. Would be nice if that will be configured parameter.

But this is a minimal possible change which is not breaking exist code and make possible to use it for AWS China region.

