### PR TITLE
fix #717: tile38_expired_keys and several other metrics not returned

### DIFF
--- a/internal/server/expire.go
+++ b/internal/server/expire.go
@@ -32,6 +32,7 @@ func (s *Server) backgroundExpireObjects(now time.Time) {
 			if nano < o.Expires() {
 				return false
 			}
+			s.statsExpired.Add(1)
 			msgs = append(msgs, &Message{Args: []string{"del", key, o.ID()}})
 			return true
 		})

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -92,13 +92,7 @@ func (s *Server) Collect(ch chan<- prometheus.Metric) {
 	s.extStats(m)
 
 	for metric, descr := range metricDescriptions {
-		val, ok := m[metric].(float64)
-		if !ok {
-			val2, ok2 := m[metric].(int)
-			if ok2 {
-				val, ok = float64(val2), true
-			}
-		}
+		val, ok := toFloat(m[metric])
 		if ok {
 			ch <- prometheus.MustNewConstMetric(descr, prometheus.GaugeValue, val)
 		}
@@ -154,4 +148,32 @@ func (s *Server) Collect(ch chan<- prometheus.Metric) {
 		)
 		return true
 	})
+}
+
+func toFloat(val interface{}) (float64, bool) {
+	switch v := val.(type) {
+	case float64:
+		return v, true
+	case int64:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case int8:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	}
+	return 0, false
 }


### PR DESCRIPTION
### Please ensure you adhere to every item in this list

- [x] This PR was pre-approved by the project maintainer
- [x] I have self-reviewed the code
- [ ] I have added all necessary tests

### Describe your changes
* `statsExpired` was never incremented
* `tile38_expired_keys` and some other metrics (seems like `tile38_total_messages_sent`) were never returned because `int64` values were never handled int Prometheus endpoint (`metrics.go`).

This is my first PR here and in Go. Apologies if something is not typical or idiomatic :-)
Feel free to close and rewrite if easier :-) Mostly wanted to illustrate the cause of the issue, as I understand it.

### Issue number and link

Fixes https://github.com/tidwall/tile38/issues/717
