### PR TITLE
fix: FSET lowercasing upper case fields

### DIFF
--- a/internal/server/crud.go
+++ b/internal/server/crud.go
@@ -841,8 +841,8 @@ func (s *Server) cmdFSET(msg *Message) (resp.Value, commandDetails, error) {
 	}
 	key, id = args[1], args[2]
 	for i := 3; i < len(args); i++ {
-		arg := strings.ToLower(args[i])
-		switch arg {
+		arg := args[i]
+		switch strings.ToLower(arg) {
 		case "xx":
 			xx = true
 		default:

--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -202,6 +202,28 @@ func keys_FSET_test(mc *mockServer) error {
 		Do("FSET", "mykey2", "myid", "a", "b").Err("key not found"),
 		Do("FSET", "mykey", "myid2", "a", "b").Err("id not found"),
 		Do("FSET", "mykey", "myid", "f2", 0).JSON().OK(),
+		Do("SET", "cases", "lower", "POINT", 1, 2).OK(),
+		Do("FSET", "cases", "lower", "lowercase", 1).JSON().OK(),
+		Do("GET", "cases", "lower", "WITHFIELDS").JSON().Str(
+			`{"ok":true,"object":{"type":"Point","coordinates":[2,1]},"fields":{"lowercase":1}}`,
+		),
+		Do("SET", "cases", "upper", "POINT", 1, 2).OK(),
+		Do("FSET", "cases", "upper", "UPPERCASE", 1).JSON().OK(),
+		Do("GET", "cases", "upper", "WITHFIELDS").JSON().Str(
+			`{"ok":true,"object":{"type":"Point","coordinates":[2,1]},"fields":{"UPPERCASE":1}}`,
+		),
+		Do("SET", "cases", "camel", "POINT", 1, 2).OK(),
+		Do("FSET", "cases", "camel", "camelCase", 1).JSON().OK(),
+		Do("GET", "cases", "camel", "WITHFIELDS").JSON().Str(
+			`{"ok":true,"object":{"type":"Point","coordinates":[2,1]},"fields":{"camelCase":1}}`,
+		),
+		Do("SET", "cases", "allcases", "POINT", 1, 2).OK(),
+		Do("FSET", "cases", "allcases", "UPPERCASE", 1).JSON().OK(),
+		Do("FSET", "cases", "allcases", "lowercase", 1).JSON().OK(),
+		Do("FSET", "cases", "allcases", "camelCase", 1).JSON().OK(),
+		Do("GET", "cases", "allcases", "WITHFIELDS").JSON().Str(
+			`{"ok":true,"object":{"type":"Point","coordinates":[2,1]},"fields":{"UPPERCASE":1,"camelCase":1,"lowercase":1}}`,
+		),
 	)
 }
 func keys_FGET_test(mc *mockServer) error {


### PR DESCRIPTION
### Please ensure you adhere to every item in this list

Figured it is minor enough to not wait your okay on this @tidwall . :pray: 

- [x] This PR was pre-approved by the project maintainer
- [x] I have self-reviewed the code
- [x] I have added all necessary tests

### Describe your changes

moving the `string.ToLower()` conversion into the switch statement instead of mutating the input argument ensures field cases are preserved. added additional tests.

```go
[...]
	for i := 3; i < len(args); i++ {
		arg := args[i]
		switch strings.ToLower(arg) {
		case "xx":
			xx = true
		default:
			fkey := arg
			i++
                        [...]
```

### Issue number and link

fixes #741 
