### PR TITLE
Add 'slave_repl_offset' to the INFO replication command output

### DIFF
--- a/internal/server/stats.go
+++ b/internal/server/stats.go
@@ -450,6 +450,7 @@ func (s *Server) writeInfoReplication(w *bytes.Buffer) {
 		fmt.Fprintf(w, "role:slave\r\n")
 		fmt.Fprintf(w, "master_host:%s\r\n", s.config.followHost())
 		fmt.Fprintf(w, "master_port:%v\r\n", s.config.followPort())
+		fmt.Fprintf(w, "slave_repl_offset:%v\r\n", int(s.faofsz))
 		if s.config.replicaPriority() >= 0 {
 			fmt.Fprintf(w, "slave_priority:%v\r\n", s.config.replicaPriority())
 		}


### PR DESCRIPTION
This adds support for `slave_repl_offset` to the `INFO REPLICATION` command.

I just grabbed the `int(s.faofsz)` from here (output of the `ROLE` command). Can you confirm this would be the right stat to grab? I don't really see where this gets updated.  I guess i could have just used the `s.aofsz` which does get updated...  

For my purposes, i guess as long as its not 0 it should fix my problem.

https://github.com/tidwall/tile38/blob/a953466318ce1d65a16259099a5b023650bfdf11/internal/server/stats.go#L633-L639


This fixes #750  
