### PR TITLE
Upgrade base image in Dockerfile to alpine:3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2
+FROM alpine:3.20
 
 ARG VERSION
 ARG TARGETOS


### PR DESCRIPTION
In another project, we had these Trivy findings for `tile38/tile38:1.33.4`:
```
[CVE-2024-0727]    libcrypto1.1    1.1.1w-r1
[CVE-2024-0727]    libssl1.1       1.1.1w-r1
```

[CVE-2024-0727](https://nvd.nist.gov/vuln/detail/cve-2024-0727) targets `openssl 1.1.1` (including) - `1.1.1x` (excluding)
* [Additional source](https://security.alpinelinux.org/vuln/CVE-2024-0727)

For `alpine:3.16.2`, it seems like the latest, supported version of openssl is `1.1.1w`.
