### PR TITLE
Fix LineString feature encoding to use all points and add tests for validation

### DIFF
--- a/internal/server/mvt.go
+++ b/internal/server/mvt.go
@@ -58,13 +58,14 @@ func mvtAddFeature(l *mvt.Layer, tileX, tileY, tileZ int, o mvtObj) {
 		f = l.AddFeature(mvt.LineString)
 		line := g.Base()
 		npoints := line.NumPoints()
-		if npoints > 0 {
-			p := line.PointAt(0)
-			f.MoveTo(mvt.LatLonXY(p.Y, p.X, tileX, tileY, tileZ))
-			for i := 1; i < npoints; i++ {
-				p := line.PointAt(0)
-				f.LineTo(mvt.LatLonXY(p.Y, p.X, tileX, tileY, tileZ))
-			}
+		if npoints < 2 {
+			return
+		}
+		p := line.PointAt(0)
+		f.MoveTo(mvt.LatLonXY(p.Y, p.X, tileX, tileY, tileZ))
+		for i := 1; i < npoints; i++ {
+			p := line.PointAt(i)
+			f.LineTo(mvt.LatLonXY(p.Y, p.X, tileX, tileY, tileZ))
 		}
 		f.AddTag("type", "linestring")
 	case *geojson.Rect:

--- a/internal/server/mvt_test.go
+++ b/internal/server/mvt_test.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tidwall/geojson"
+	"github.com/tidwall/geojson/geometry"
+	"github.com/tidwall/mvt"
+)
+
+func ls(points []geometry.Point) *geojson.LineString {
+	return geojson.NewLineString(geometry.NewLine(points, nil))
+}
+
+// Ensure that LineString features are encoded using
+// all points in the geometry, not just the first one.
+func TestMVTAddFeatureLineStringUsesAllPoints(t *testing.T) {
+	tileX, tileY, tileZ := 0, 0, 0
+
+	line := ls([]geometry.Point{
+		{X: 1, Y: 1},
+		{X: 2, Y: 2},
+		{X: 3, Y: 3},
+	})
+	id := "line"
+
+	actual := mvtRender(tileX, tileY, tileZ, []mvtObj{{id: id, obj: line}})
+
+	var tile mvt.Tile
+	layer := tile.AddLayer("tile38")
+	layer.SetExtent(4096)
+
+	f := layer.AddFeature(mvt.LineString)
+	series := line.Base()
+	npoints := series.NumPoints()
+	if npoints < 2 {
+		t.Fatalf("expected at least two points, got %d", npoints)
+	}
+	p := series.PointAt(0)
+	x, y := mvt.LatLonXY(p.Y, p.X, tileX, tileY, tileZ)
+	f.MoveTo(x, y)
+	for i := 1; i < npoints; i++ {
+		p = series.PointAt(i)
+		x, y = mvt.LatLonXY(p.Y, p.X, tileX, tileY, tileZ)
+		f.LineTo(x, y)
+	}
+	f.AddTag("type", "linestring")
+	f.AddTag("id", id)
+
+	expected := tile.Render()
+
+	if !bytes.Equal(actual, expected) {
+		t.Fatalf("mvtAddFeature LineString encoding mismatch")
+	}
+}
+
+// LineStrings with fewer than two points should not
+// produce any geometry commands.
+func TestMVTAddFeatureLineStringTooShort(t *testing.T) {
+	tileX, tileY, tileZ := 0, 0, 0
+
+	line := ls([]geometry.Point{
+		{X: 1, Y: 1},
+	})
+
+	actual := mvtRender(tileX, tileY, tileZ, []mvtObj{{id: "short", obj: line}})
+
+	var tile mvt.Tile
+	layer := tile.AddLayer("tile38")
+	layer.SetExtent(4096)
+	_ = layer.AddFeature(mvt.LineString)
+
+	expected := tile.Render()
+
+	if !bytes.Equal(actual, expected) {
+		t.Fatalf("mvtAddFeature LineString with <2 points should not encode geometry")
+	}
+}
+


### PR DESCRIPTION
This pull request improves the handling and testing of LineString features in the MVT encoding logic. The main change ensures that LineString features are only encoded if they contain at least two points, and that all points are used in the encoding process. New tests have been added to verify this behavior.

### LineString encoding improvements

* Updated `mvtAddFeature` in `internal/server/mvt.go` to only encode LineString features with two or more points, and fixed a bug where only the first point was used in the loop instead of all points.

### Testing enhancements

* Added new tests in `internal/server/mvt_test.go` to verify that LineString features are encoded using all points, and that LineStrings with fewer than two points do not produce geometry commands.