### PR TITLE
Mqtt add SSL and user 

### DIFF
--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -103,6 +103,7 @@ type Endpoint struct {
 		CACertFile string
 		CertFile   string
 		KeyFile    string
+		SSL        bool
 		User       string
 		Pass       string
 	}
@@ -300,6 +301,8 @@ func parseEndpoint(s string) (Endpoint, error) {
 	case strings.HasPrefix(s, "amqps:"):
 		endpoint.Protocol = AMQP
 	case strings.HasPrefix(s, "mqtt:"):
+		endpoint.Protocol = MQTT
+	case strings.HasPrefix(s, "mqtts:"):
 		endpoint.Protocol = MQTT
 	case strings.HasPrefix(s, "pubsub:"):
 		endpoint.Protocol = PubSub
@@ -562,6 +565,10 @@ func parseEndpoint(s string) (Endpoint, error) {
 					endpoint.MQTT.Pass = val[0]
 				}
 			}
+		}
+
+		if strings.HasPrefix(endpoint.Original, "mqtts:") {
+			endpoint.MQTT.SSL = true
 		}
 
 		// Throw error if we not provide any queue name

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -103,6 +103,8 @@ type Endpoint struct {
 		CACertFile string
 		CertFile   string
 		KeyFile    string
+		User       string
+		Pass       string
 	}
 	PubSub struct {
 		Project  string
@@ -554,6 +556,10 @@ func parseEndpoint(s string) (Endpoint, error) {
 					endpoint.MQTT.CertFile = val[0]
 				case "key":
 					endpoint.MQTT.KeyFile = val[0]
+				case "user":
+					endpoint.MQTT.User = val[0]
+				case "pass":
+					endpoint.MQTT.Pass = val[0]
 				}
 			}
 		}

--- a/internal/endpoint/mqtt.go
+++ b/internal/endpoint/mqtt.go
@@ -68,7 +68,12 @@ func (conn *MQTTConn) Send(msg string) error {
 	conn.t = time.Now()
 
 	if conn.conn == nil {
-		uri := fmt.Sprintf("tcp://%s:%d", conn.ep.MQTT.Host, conn.ep.MQTT.Port)
+		prefix := "tcp://"
+		if conn.ep.MQTT.SSL {
+			prefix = "ssl://"
+		}
+
+		uri := fmt.Sprintf("%s%s:%d", prefix, conn.ep.MQTT.Host, conn.ep.MQTT.Port)
 		ops := paho.NewClientOptions()
 		if conn.ep.MQTT.CertFile != "" || conn.ep.MQTT.KeyFile != "" ||
 			conn.ep.MQTT.CACertFile != "" {
@@ -113,6 +118,7 @@ func (conn *MQTTConn) Send(msg string) error {
 		c := paho.NewClient(ops)
 
 		if token := c.Connect(); token.Wait() && token.Error() != nil {
+			log.Debugf("Failed to connect mqtt with error: %v", token.Error())
 			return token.Error()
 		}
 
@@ -123,6 +129,7 @@ func (conn *MQTTConn) Send(msg string) error {
 		conn.ep.MQTT.Retained, msg)
 
 	if !t.WaitTimeout(mqttPublishTimeout) || t.Error() != nil {
+		log.Debugf("Failed to publish mqtt message with error: %v", t.Error())
 		conn.close()
 		return t.Error()
 	}

--- a/internal/endpoint/mqtt.go
+++ b/internal/endpoint/mqtt.go
@@ -101,8 +101,15 @@ func (conn *MQTTConn) Send(msg string) error {
 			return err
 		}
 		uuid := fmt.Sprintf("tile38-%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
-
 		ops = ops.SetClientID(uuid).AddBroker(uri)
+
+		if conn.ep.MQTT.User != "" {
+			ops = ops.SetUsername(conn.ep.MQTT.User)
+		}
+		if conn.ep.MQTT.Pass != "" {
+			ops = ops.SetPassword(conn.ep.MQTT.Pass)
+		}
+
 		c := paho.NewClient(ops)
 
 		if token := c.Connect(); token.Wait() && token.Error() != nil {


### PR DESCRIPTION
### Describe your changes
MQTT endpoint improvements:
- Add SSL Support with the prefix `mqtts:`
- Add arguments 'user' and 'pass' for authentication to the broker

### Describe your changes
With this changes, is it now possible to setup a mqtt hook to a secured endpoint that requires authentication like the most public broker (i tested with EMQX)

To Setup the hook use the new parameters: **mqtts**://broker.emqx.io:8883/zone1?**user**=user1&**pass**=public123

### Issue number and link
#810 


> After the PR is accepted, i will update the documentation :) 

