### PR TITLE
ci: upgrade GitHub Actions to current stable (Node 24 runtime)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: ^1.26
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
  ### Describe your changes

  The `Go` workflow pinned `actions/checkout@v2` and `actions/setup-go@v2`,
  which run on the deprecated Node 20 runtime (GitHub emits a deprecation
  warning on every run). This bumps both to the current stable majors,
  which run on the supported Node 24 runtime:

  - `actions/checkout@v2` → `@v6` (v6.0.3)
  - `actions/setup-go@v2` → `@v6` (v6.4.0)

  No change to the build/test/package/push behavior — runtime upgrade only.

  ### Notes

  - This is small CI maintenance with no behavioral change, so I didn't
    file a separate issue first — happy to open one if you'd prefer.